### PR TITLE
Small tweak to hierarchy file reader - patch for pre-AP simulations

### DIFF
--- a/src/enzo/New_Grid_ReadGrid.C
+++ b/src/enzo/New_Grid_ReadGrid.C
@@ -198,27 +198,18 @@ int grid::Group_ReadGrid(FILE *fptr, int GridID, HDF5_hid_t file_id,
             ENZO_FAIL("error reading NumberOfParticles.");
     }
 
-    int ActiveParticlesExist = 0;
-
-     if (fscanf(fptr, "NumberOfActiveParticles = %"ISYM"\n", &NumberOfActiveParticles) == 1) {
-       fgets(unused_string, MAX_LINE_LENGTH, fptr);
-       fgets(unused_string, MAX_LINE_LENGTH, fptr);
-     } else {
-       NumberOfActiveParticles = 0;
-     }
-      // Ugly hack to support restart files from before active particle support
-      NumberOfActiveParticles = 0;
+    /* Read in the number of active particles from the next line.  If fscanf returns 1, we have a dataset
+       from after the active particles were added and thus we have a couple of extra lines of text that 
+       need to be read (but which are not currently used).  If fscanf does not return 1 this particular line 
+       doesn't have any active particle information in it, and thus we have to manually set NumberOfActiveParticles
+       to zero. */
+    if (fscanf(fptr, "NumberOfActiveParticles = %"ISYM"\n", &NumberOfActiveParticles) == 1) {
+      // read but unused
+      fgets(unused_string, MAX_LINE_LENGTH, fptr);
+      fgets(unused_string, MAX_LINE_LENGTH, fptr);
     } else {
-      // But we still need to know that active particles do NOT exist (see immediately below)
-      ActiveParticlesExist = 1;
-    }
-
-    // We read these in but don't use them (yet?). Therefore we won't error
-    // out if we can't read them in.  BUT, don't read them in if this parameter
-    // file predates the active particle code!
-    if(ActiveParticlesExist>0){
-      fgets(unused_string, MAX_LINE_LENGTH, fptr);
-      fgets(unused_string, MAX_LINE_LENGTH, fptr);
+      // manually set number of active particles to zero (for simulations from the pre-AP era)
+      NumberOfActiveParticles = 0;
     }
 
     if ((NumberOfParticles > 0) || (NumberOfActiveParticles > 0)) {

--- a/src/enzo/New_Grid_ReadGrid.C
+++ b/src/enzo/New_Grid_ReadGrid.C
@@ -198,15 +198,23 @@ int grid::Group_ReadGrid(FILE *fptr, int GridID, HDF5_hid_t file_id,
             ENZO_FAIL("error reading NumberOfParticles.");
     }
 
+    int ActiveParticlesExist = 0;
+
     if (fscanf(fptr, "NumberOfActiveParticles = %"ISYM"\n", &NumberOfActiveParticles) != 1) {
       // Ugly hack to support restart files from before active particle support
       NumberOfActiveParticles = 0;
+    } else {
+      // But we still need to know that active particles do NOT exist (see immediately below)
+      ActiveParticlesExist = 1;
     }
 
     // We read these in but don't use them (yet?). Therefore we won't error
-    // out if we can't read them in.
-    fgets(unused_string, MAX_LINE_LENGTH, fptr);
-    fgets(unused_string, MAX_LINE_LENGTH, fptr);
+    // out if we can't read them in.  BUT, don't read them in if this parameter
+    // file predates the active particle code!
+    if(ActiveParticlesExist>0){
+      fgets(unused_string, MAX_LINE_LENGTH, fptr);
+      fgets(unused_string, MAX_LINE_LENGTH, fptr);
+    }
 
     if ((NumberOfParticles > 0) || (NumberOfActiveParticles > 0)) {
  

--- a/src/enzo/New_Grid_ReadGrid.C
+++ b/src/enzo/New_Grid_ReadGrid.C
@@ -200,7 +200,12 @@ int grid::Group_ReadGrid(FILE *fptr, int GridID, HDF5_hid_t file_id,
 
     int ActiveParticlesExist = 0;
 
-    if (fscanf(fptr, "NumberOfActiveParticles = %"ISYM"\n", &NumberOfActiveParticles) != 1) {
+     if (fscanf(fptr, "NumberOfActiveParticles = %"ISYM"\n", &NumberOfActiveParticles) == 1) {
+       fgets(unused_string, MAX_LINE_LENGTH, fptr);
+       fgets(unused_string, MAX_LINE_LENGTH, fptr);
+     } else {
+       NumberOfActiveParticles = 0;
+     }
       // Ugly hack to support restart files from before active particle support
       NumberOfActiveParticles = 0;
     } else {


### PR DESCRIPTION
This is described by the discussion in Issue #79 , and implements the fix described there.  It fixes a bug where the recently-accepted active particle PR (PR #57 ) breaks restarts from simulations that have particles but predate the active particle PR merge (which is to say, almost all Enzo simulations ever).