### PR TITLE
Fixes to map RadiationRedshift* parameters to Grackle

### DIFF
--- a/src/enzo/ReadParameterFile.C
+++ b/src/enzo/ReadParameterFile.C
@@ -1750,10 +1750,14 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     grackle_data->HydrogenFractionByMass         = (double) CoolData.HydrogenFractionByMass;
     grackle_data->DeuteriumToHydrogenRatio       = (double) CoolData.DeuteriumToHydrogenRatio;
     grackle_data->SolarMetalFractionByMass       = (double) CoolData.SolarMetalFractionByMass;
+    grackle_data->UVbackground_redshift_on       = (double) CoolData.RadiationRedshiftOn;
+    grackle_data->UVbackground_redshift_off      = (double) CoolData.RadiationRedshiftOff;
+    grackle_data->UVbackground_redshift_fullon   = (double) CoolData.RadiationRedshiftFullOn;
+    grackle_data->UVbackground_redshift_drop     = (double) CoolData.RadiationRedshiftDropOff;
     grackle_data->use_radiative_transfer         = (Eint32) RadiativeTransfer;
     // grackle_data->radiative_transfer_coupled_rate_solver set in RadiativeTransferReadParameters
     // grackle_data->radiative_transfer_hydrogen_only set in RadiativeTransferReadParameters
-
+    
     // Initialize units structure.
     FLOAT a_value, dadt;
     a_value = 1.0;


### PR DESCRIPTION
This is a quick fix to make Enzo to be fully functional with all of Grackle’s features.  (Previously these four Enzo parameters were not mapped to their respective Grackle parameters.)  This fix -- identified by myself (Ji-hoon) and Britton -- will also make Enzo to be fully compatible with other codes in the AGORA comparison test suites of cosmological runs.  

(FYI, the only other place where RadiationRedshift* parameters are used is in Enzo is RadiationFieldCalculateRates.C.  This file is not used anyway if RadiationFieldType = 0 -- which is often the case when Grackle is employed for cooling/radiation calculations.)  