### PR TITLE
Fixing MinimumPressureSupport in hydro_rk solvers

### DIFF
--- a/src/enzo/Grid.h
+++ b/src/enzo/Grid.h
@@ -2754,7 +2754,7 @@ int zEulerSweep(int j, int NumberOfSubgrids, fluxes *SubgridFluxes[],
   int UpdatePrim(float **dU, float c1, float c2);
   int Hydro3D(float **Prim, float **dU, float dt,
 	      fluxes *SubgridFluxes[], int NumberOfSubgrids,
-	      float fluxcoef, int fallback);
+	      float fluxcoef, float min_coeff, int fallback);
   int TurbulenceInitializeGrid(float CloudDensity, float CloudSoundSpeed, FLOAT CloudRadius, 
 			       float CloudMachNumber, float CloudAngularVelocity, float InitialBField,
 			       int SetTurbulence, int CloudType, int TurbulenceSeed, int PutSink, 
@@ -2778,7 +2778,7 @@ int zEulerSweep(int j, int NumberOfSubgrids, fluxes *SubgridFluxes[],
 			       int   sphere_type,
 			       float rho_medium, float p_medium);
   int AddSelfGravity(float coef);
-  int SourceTerms(float **dU);
+  int SourceTerms(float **dU, float min_coeff);
   int MHD1DTestInitializeGrid(float rhol, float rhor,
 			      float vxl,  float vxr,
 			      float vyl,  float vyr,
@@ -2873,8 +2873,8 @@ int zEulerSweep(int j, int NumberOfSubgrids, fluxes *SubgridFluxes[],
 		     ExternalBoundary *Exterior);
   int MHD3D(float **Prim, float **dU, float dt,
 	    fluxes *SubgridFluxes[], int NumberOfSubgrids,
-	    float fluxcoef, int fallback);
-  int MHDSourceTerms(float **dU);
+	    float fluxcoef, float min_coeff, int fallback);
+  int MHDSourceTerms(float **dU, float min_coeff);
   int UpdateMHDPrim(float **dU, float c1, float c2);
   int SaveMHDSubgridFluxes(fluxes *SubgridFluxes[], int NumberOfSubgrids,
 			   float *Flux3D[], int flux, float fluxcoef, float dt);

--- a/src/enzo/hydro_rk/Grid_Hydro3D.C
+++ b/src/enzo/hydro_rk/Grid_Hydro3D.C
@@ -26,15 +26,15 @@
 
 int CosmologyComputeExpansionFactor(FLOAT time, FLOAT *a, FLOAT *dadt);
 int HydroSweepX(float **Prim,  float **Flux3D, int GridDimension[], 
-		int GridStartIndex[], FLOAT **CellWidth, float dtdx, int fallback);
+		int GridStartIndex[], FLOAT **CellWidth, float dtdx, float min_coeff, int fallback);
 int HydroSweepY(float **Prim,  float **Flux3D, int GridDimension[], 
-		int GridStartIndex[], FLOAT **CellWidth, float dtdx, int fallback);
+		int GridStartIndex[], FLOAT **CellWidth, float dtdx, float min_coeff, int fallback);
 int HydroSweepZ(float **Prim,  float **Flux3D, int GridDimension[], 
-		int GridStartIndex[], FLOAT **CellWidth, float dtdx, int fallback);
+		int GridStartIndex[], FLOAT **CellWidth, float dtdx, float min_coeff, int fallback);
 
 int grid::Hydro3D(float **Prim, float **dU, float dt,
 		  fluxes *SubgridFluxes[], int NumberOfSubgrids, 
-		  float fluxcoef, int fallback)
+		  float fluxcoef, float min_coeff, int fallback)
   /* 
      Input:  U[NEQ_SRHYDRO][GridDimension^3]: the conserved variables vector 
                                               including ghost zones.
@@ -90,7 +90,7 @@ int grid::Hydro3D(float **Prim, float **dU, float dt,
 
   // compute flux at cell faces in x direction
   float dtdx = dt/(a*CellWidth[0][0]);
-  if (HydroSweepX(Prim, Flux3D, GridDimension, GridStartIndex, CellWidth, dtdx, fallback) == FAIL) {
+  if (HydroSweepX(Prim, Flux3D, GridDimension, GridStartIndex, CellWidth, dtdx, min_coeff, fallback) == FAIL) {
     return FAIL;
   }
 
@@ -145,7 +145,7 @@ int grid::Hydro3D(float **Prim, float **dU, float dt,
   if (GridRank > 1) {
     dtdx = dt/(a*CellWidth[1][0]);
     // compute flux in y direction
-    if (HydroSweepY(Prim, Flux3D, GridDimension, GridStartIndex, CellWidth, dtdx, fallback) == FAIL)
+    if (HydroSweepY(Prim, Flux3D, GridDimension, GridStartIndex, CellWidth, dtdx, min_coeff, fallback) == FAIL)
       return FAIL;
 
     // Update dU
@@ -204,7 +204,7 @@ int grid::Hydro3D(float **Prim, float **dU, float dt,
   if (GridRank > 2) {
     dtdx = dt/(a*CellWidth[2][0]);
     // compute flux in z direction
-    if (HydroSweepZ(Prim, Flux3D, GridDimension, GridStartIndex, CellWidth, dtdx, fallback) == FAIL)
+    if (HydroSweepZ(Prim, Flux3D, GridDimension, GridStartIndex, CellWidth, dtdx, min_coeff, fallback) == FAIL)
       return FAIL;
 
     // Update dU

--- a/src/enzo/hydro_rk/Grid_MHD3D.C
+++ b/src/enzo/hydro_rk/Grid_MHD3D.C
@@ -24,16 +24,16 @@
 #include "Grid.h"
 
 int MHDSweepX(float **Prim,  float **Flux3D, int GridDimension[], 
-	      int GridStartIndex[], FLOAT **CellWidth, float dtdx, int fallback);
+	      int GridStartIndex[], FLOAT **CellWidth, float dtdx, float min_coeff, int fallback);
 int MHDSweepY(float **Prim,  float **Flux3D, int GridDimension[], 
-	      int GridStartIndex[], FLOAT **CellWidth, float dtdx, int fallback);
+	      int GridStartIndex[], FLOAT **CellWidth, float dtdx, float min_coeff, int fallback);
 int MHDSweepZ(float **Prim,  float **Flux3D, int GridDimension[], 
-	      int GridStartIndex[], FLOAT **CellWidth, float dtdx, int fallback);
+	      int GridStartIndex[], FLOAT **CellWidth, float dtdx, float min_coeff, int fallback);
 int CosmologyComputeExpansionFactor(FLOAT time, FLOAT *a, FLOAT *dadt);
 
 int grid::MHD3D(float **Prim, float **dU, float dt,
 		fluxes *SubgridFluxes[], int NumberOfSubgrids, 
-		float fluxcoef, int fallback)
+		float fluxcoef, float min_coeff, int fallback)
   /* 
      Input:  U[NEQ_SRHYDRO][GridDimension^3]: the conserved variables vector 
                                               including ghost zones.
@@ -97,7 +97,7 @@ int grid::MHD3D(float **Prim, float **dU, float dt,
 
   // compute flux at cell faces in x direction
   FLOAT dtdx = dt/(a*CellWidth[0][0]);
-  if (MHDSweepX(Prim, Flux3D, GridDimension, GridStartIndex, CellWidth, dtdx, fallback) 
+  if (MHDSweepX(Prim, Flux3D, GridDimension, GridStartIndex, CellWidth, dtdx, min_coeff, fallback) 
       == FAIL) {
     return FAIL;
   }
@@ -157,7 +157,7 @@ int grid::MHD3D(float **Prim, float **dU, float dt,
   if (GridRank > 1) {
     dtdx = dt/(a*CellWidth[1][0]);
     // compute flux in y direction
-    if (MHDSweepY(Prim, Flux3D, GridDimension, GridStartIndex, CellWidth, dtdx, fallback) 
+    if (MHDSweepY(Prim, Flux3D, GridDimension, GridStartIndex, CellWidth, dtdx, min_coeff, fallback) 
 	== FAIL)
       return FAIL;
 
@@ -192,7 +192,7 @@ int grid::MHD3D(float **Prim, float **dU, float dt,
   if (GridRank > 2) {
     dtdx = dt/(a*CellWidth[2][0]);
     // compute flux in z direction
-    if (MHDSweepZ(Prim, Flux3D, GridDimension, GridStartIndex, CellWidth, dtdx, fallback) 
+    if (MHDSweepZ(Prim, Flux3D, GridDimension, GridStartIndex, CellWidth, dtdx, min_coeff, fallback) 
 	== FAIL)
       return FAIL;
 

--- a/src/enzo/hydro_rk/Grid_MHDRK2_2ndStep.C
+++ b/src/enzo/hydro_rk/Grid_MHDRK2_2ndStep.C
@@ -81,17 +81,24 @@ int grid::MHDRK2_2ndStep(fluxes *SubgridFluxes[],
 
   this->ReturnHydroRKPointers(Prim, true);  //##### added! because Hydro3D needs fractions for species
 
+  float MinimumSupportEnergyCoefficient = 0;
+  if (UseMinimumPressureSupport && level == MaximumRefinementLevel)
+    if (this->SetMinimumSupport(MinimumSupportEnergyCoefficient) == FAIL) {
+      ENZO_FAIL("Error in grid->SetMinimumSupport");
+    }
+
+
   /* Compute dU */
 
   int fallback = 0;
   if (this->MHD3D(Prim, dU, dtFixed, SubgridFluxes, NumberOfSubgrids, 
-		  0.5, fallback) == FAIL) {
+		  0.5, MinimumSupportEnergyCoefficient, fallback) == FAIL) {
     return FAIL;
   }
 
   /* Add source terms */
 
-  this->MHDSourceTerms(dU);
+    this->MHDSourceTerms(dU, MinimumSupportEnergyCoefficient);
 
   /* Update primitive variables */
 
@@ -110,10 +117,10 @@ int grid::MHDRK2_2ndStep(fluxes *SubgridFluxes[],
     this->ZeroFluxes(SubgridFluxes, NumberOfSubgrids);
     fallback = 1;
     if (this->MHD3D(Prim, dU, dtFixed, SubgridFluxes, NumberOfSubgrids, 
-                    0.5, fallback) == FAIL) {
+                    0.5, MinimumSupportEnergyCoefficient, fallback) == FAIL) {
       return FAIL;
     }
-    this->MHDSourceTerms(dU);
+      this->MHDSourceTerms(dU, MinimumSupportEnergyCoefficient);
     if (this->UpdateMHDPrim(dU, 0.5, 0.5) == FAIL) {
       fprintf(stderr, "Grid_MHDRK2_2ndStep: Fallback failed, give up...\n");
       return FAIL;

--- a/src/enzo/hydro_rk/Grid_MHDSourceTerms.C
+++ b/src/enzo/hydro_rk/Grid_MHDSourceTerms.C
@@ -37,7 +37,7 @@ int FindField(int field, int farray[], int numfields);
 void mt_init(unsigned_int seed);
 unsigned_long_int mt_random();
 
-int grid::MHDSourceTerms(float **dU)
+int grid::MHDSourceTerms(float **dU, float min_coeff)
 {
 
   if (ProcessorNumber != MyProcessorNumber) {
@@ -65,11 +65,6 @@ int grid::MHDSourceTerms(float **dU)
     FLOAT dtdx = coef*dtFixed/CellWidth[0][0]/a,
       dtdy = (GridRank > 1) ? coef*dtFixed/CellWidth[1][0]/a : 0.0,
       dtdz = (GridRank > 2) ? coef*dtFixed/CellWidth[2][0]/a : 0.0;
-    float min_coeff = 0.0;
-    if (UseMinimumPressureSupport) {
-      min_coeff = MinimumPressureSupportParameter*
-	0.32*pow(CellWidth[0][0],2)/(Gamma*(Gamma-1.0));
-    }
     float rho, eint, p, divVdt, h, cs, dpdrho, dpde;
     int n = 0;
     for (int k = GridStartIndex[2]; k <= GridEndIndex[2]; k++) {

--- a/src/enzo/hydro_rk/Grid_SourceTerms.C
+++ b/src/enzo/hydro_rk/Grid_SourceTerms.C
@@ -32,7 +32,7 @@ int GetUnits(float *DensityUnits, float *LengthUnits,
 	     float *TemperatureUnits, float *TimeUnits,
 	     float *VelocityUnits, FLOAT Time);
 
-int grid::SourceTerms(float **dU)
+int grid::SourceTerms(float **dU, float min_coeff)
 {
 
   if (ProcessorNumber != MyProcessorNumber) {
@@ -68,11 +68,6 @@ int grid::SourceTerms(float **dU)
 	dtdy = (GridRank > 1) ? 0.5*dtFixed/CellWidth[1][0]/a : 0.0,
 	dtdz = (GridRank > 2) ? 0.5*dtFixed/CellWidth[2][0]/a : 0.0;
       float rho, eint, p, divVdt, h, cs, dpdrho, dpde;
-      float min_coeff = 0.0;
-      if (UseMinimumPressureSupport) {
-	min_coeff = MinimumPressureSupportParameter*
-	  0.48999*pow(CellWidth[0][0],2)/(Gamma*(Gamma-1.0));
-      }
       int n = 0;
       for (int k = GridStartIndex[2]; k <= GridEndIndex[2]; k++) {
 	for (int j = GridStartIndex[1]; j <= GridEndIndex[1]; j++) {

--- a/src/enzo/hydro_rk/HydroSweepX.C
+++ b/src/enzo/hydro_rk/HydroSweepX.C
@@ -30,7 +30,7 @@ int HydroLine(float **Prim, float **priml, float **primr,
 
 
 int HydroSweepX(float **Prim, float **Flux3D, int GridDimension[], 
-		int GridStartIndex[], FLOAT **CellWidth, float dtdx, int fallback)
+		int GridStartIndex[], FLOAT **CellWidth, float dtdx, float min_coeff, int fallback)
   /*
     Input: U[NEQ_HYDRO][GridDimension^3].
            Prim[NEQ_HYDRO+1][GridDimension^3].
@@ -70,14 +70,6 @@ int HydroSweepX(float **Prim, float **Flux3D, int GridDimension[],
 
   for (int field = 0; field < NColor; field ++) {
     colors[field] = new float[Xactivesize+1];
-  }
-
-
-  float min_coeff = 0.0;
-  if (UseMinimumPressureSupport) {
-    min_coeff = GravitationalConstant/(4.0*pi) / (pi * (Gamma*(Gamma-1.0))) *
-      MinimumPressureSupportParameter *
-      CellWidth[0][0] * CellWidth[0][0];
   }
 
   float etot, vx, vy, vz, v2, p;

--- a/src/enzo/hydro_rk/HydroSweepY.C
+++ b/src/enzo/hydro_rk/HydroSweepY.C
@@ -30,7 +30,7 @@ int HydroLine(float **Prim, float **priml, float **primr,
 		float dtdx, char direc, int ij, int ik, int fallback);
 
 int HydroSweepY(float **Prim, float **Flux3D, int GridDimension[], 
-		int GridStartIndex[], FLOAT **CellWidth, float dtdx, int fallback)
+		int GridStartIndex[], FLOAT **CellWidth, float dtdx, float min_coeff, int fallback)
   /*
     Input: U[NEQ_HYDRO][GridDimension^3].
            Prim[NEQ_HYDRO+1][GridDimension^3].
@@ -68,14 +68,6 @@ int HydroSweepY(float **Prim, float **Flux3D, int GridDimension[],
 
   for (int field = 0; field < NColor; field ++) {
     colors[field] = new float[Yactivesize+1];
-  }
-
-
-  float min_coeff = 0.0;
-  if (UseMinimumPressureSupport) {
-    min_coeff = GravitationalConstant/(4.0*pi) / (pi * (Gamma*(Gamma-1.0))) *
-      MinimumPressureSupportParameter *
-      CellWidth[0][0] * CellWidth[0][0];
   }
 
   float etot, vx, vy, vz, v2, p;

--- a/src/enzo/hydro_rk/HydroSweepZ.C
+++ b/src/enzo/hydro_rk/HydroSweepZ.C
@@ -30,7 +30,7 @@ int HydroLine(float **Prim, float **priml, float **primr,
 	      float dtdx, char direc, int ij, int ik, int fallback);
 
 int HydroSweepZ(float **Prim, float **Flux3D, int GridDimension[], 
-		int GridStartIndex[], FLOAT **CellWidth, float dtdx, int fallback)
+		int GridStartIndex[], FLOAT **CellWidth, float dtdx, float min_coeff, int fallback)
   /*
     Input: U[NEQ_HYDRO][GridDimension^3].
            Prim[NEQ_HYDRO+1][GridDimension^3].
@@ -68,15 +68,6 @@ int HydroSweepZ(float **Prim, float **Flux3D, int GridDimension[],
 
   for (int field = 0; field < NColor; field ++) {
     colors[field] = new float[Zactivesize+1];
-  }
-
-
- 
-  float min_coeff = 0.0;
-  if (UseMinimumPressureSupport) {
-    min_coeff = GravitationalConstant/(4.0*pi) / (pi * (Gamma*(Gamma-1.0))) *
-      MinimumPressureSupportParameter *
-      CellWidth[0][0] * CellWidth[0][0];
   }
 
   float etot, vx, vy, vz, v2, p;

--- a/src/enzo/hydro_rk/MHDSweepX.C
+++ b/src/enzo/hydro_rk/MHDSweepX.C
@@ -29,7 +29,7 @@ int MHDLine(float **Prim, float **priml, float **primr,
 	    float dtdx, char direc, int jj, int kk, int fallback);
 
 int MHDSweepX(float **Prim, float **Flux3D, int GridDimension[], 
-	      int GridStartIndex[], FLOAT **CellWidth, float dtdx, int fallback)
+	      int GridStartIndex[], FLOAT **CellWidth, float dtdx, float min_coeff, int fallback)
   /*
     Input: U[NEQ_MHD][GridDimension^3].
            Prim[NEQ_MHD+1][GridDimension^3].
@@ -74,13 +74,6 @@ int MHDSweepX(float **Prim, float **Flux3D, int GridDimension[],
 
   float etot, vx, vy, vz, v2, p, Bx, By, Bz, B2, rho;
   
-  float min_coeff = 0.0;
-  if (UseMinimumPressureSupport) {
-    min_coeff = MinimumPressureSupportParameter*
-      0.32*pow(CellWidth[0][0],2)/(Gamma*(Gamma-1.0));
-  }
-
-
   for (k = 0; k < Zactivesize; k++) {
     for (j = 0; j < Yactivesize; j++) {
 

--- a/src/enzo/hydro_rk/MHDSweepY.C
+++ b/src/enzo/hydro_rk/MHDSweepY.C
@@ -29,7 +29,7 @@ int MHDLine(float **Prim, float **priml, float **primr,
 	    float dtdx, char direc, int jj, int kk, int fallback);
 
 int MHDSweepY(float **Prim, float **Flux3D, int GridDimension[], 
-	      int GridStartIndex[], FLOAT **CellWidth, float dtdx, int fallback)
+	      int GridStartIndex[], FLOAT **CellWidth, float dtdx, float min_coeff, int fallback)
   /*
     Input: U[NEQ_MHD][GridDimension^3].
            Prim[NEQ_MHD+1][GridDimension^3].
@@ -66,12 +66,6 @@ int MHDSweepY(float **Prim, float **Flux3D, int GridDimension[],
 
   for (int field = 0; field < NColor; field ++) {
     colors[field] = new float[Yactivesize+1];
-  }
-
-  float min_coeff = 0.0;
-  if (UseMinimumPressureSupport) {
-    min_coeff = MinimumPressureSupportParameter*
-      0.32*pow(CellWidth[1][0],2)/(Gamma*(Gamma-1.0));
   }
 
   float etot, vx, vy, vz, v2, p, Bx, By, Bz, B2, rho;

--- a/src/enzo/hydro_rk/MHDSweepZ.C
+++ b/src/enzo/hydro_rk/MHDSweepZ.C
@@ -29,7 +29,7 @@ int MHDLine(float **Prim, float **priml, float **primr,
 	    float dtdx, char direc, int jj, int kk, int fallback);
 
 int MHDSweepZ(float **Prim, float **Flux3D, int GridDimension[], 
-	      int GridStartIndex[], FLOAT **CellWidth, float dtdx, int fallback)
+	      int GridStartIndex[], FLOAT **CellWidth, float dtdx, float min_coeff, int fallback)
   /*
     Input: U[NEQ_MHD][GridDimension^3].
            Prim[NEQ_MHD+1][GridDimension^3].
@@ -66,12 +66,6 @@ int MHDSweepZ(float **Prim, float **Flux3D, int GridDimension[],
 
   for (int field = 0; field < NColor; field ++) {
     colors[field] = new float[Zactivesize+1];
-  }
-
-  float min_coeff = 0.0;
-  if (UseMinimumPressureSupport) {
-    min_coeff = MinimumPressureSupportParameter*
-      0.32*pow(CellWidth[2][0],2)/(Gamma*(Gamma-1.0));
   }
 
   float etot, vx, vy, vz, v2, p, rho, Bx, By, Bz, B2;


### PR DESCRIPTION
The implementation of the MinimumPressureSupportParameter in HydroMethod = 3 and 4 was inconsistent between the two HydroMethods, had hard-coded parameters, and didn't match the implementation in the Zeus solver. When I ran a cosmological simulation with MinimumPressureSupport and the hydro solvers, I got some pretty unphysical values in the temperature and gas energy.  This fix keeps the original framework of the MinimumPressureSupport implementation found in the hydro_rk/ files, but calculates the "min_coeff" parameter with Grid_SetMinimumSupport for consistency.