### PR TITLE
Add test of various compile options.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ commands:
           make -j 4 || (make show-config ; exit 1)
           make use-mpi-yes
           # test ray-tracing
-          make use-photon-no
+          make photon-no
           make clean
           make -j 4 || (make show-config ; exit 1)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,7 @@ commands:
       - run: |
           source $BASH_ENV
           source $HOME/venv/bin/activate
+          alias build-enzo='make -j 4 || (make show-config ; exit 1)'
           ./configure
           cd src/enzo
           make machine-linux-gnu
@@ -119,7 +120,7 @@ commands:
           make precision-$prec
           make particles-$part
           make clean
-          make -j 4 || make show-config
+          build-enzo
           done ; done
           # return this to default
           make precision-64
@@ -135,12 +136,12 @@ commands:
           make integers-$inte
           make particle-id-$pids
           make clean
-          make -j 4 || make show-config
+          build-enzo
           done ; done
           # test without mpi
           make use-mpi-no
           make clean
-          make -j 4 || make show-config
+          build-enzo
 
   build-docs:
     description: "Test the docs build."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,47 @@ commands:
             python ./test_runner.py --suite=push -o $ENZOTEST_DIR --answer-name=$ANSWER_NAME --local --strict=high --verbose << parameters.flags >>
           fi
 
+  compile-test:
+    description: "Test that enzo compiles in a few different configurations."
+    steps:
+      - run: |
+          source $BASH_ENV
+          source $HOME/venv/bin/activate
+          ./configure
+          cd src/enzo
+          make machine-linux-gnu
+          make load-config-test-suite
+          # test various baryon/particle precisions
+          for prec in 32 64
+          do for part in 32 64 128
+          do
+          if [ $prec == $part ]; then
+          continue
+          fi
+          make precision-$prec
+          make particles-$part
+          make clean
+          make -j 4
+          done ; done
+          # return this to default
+          make particles-64
+          # test various integer/particle-id precisions
+          for inte in 32 64
+          do for pids in 32 64
+          do
+          if [ $inte == $pids ]; then
+          continue
+          fi
+          make integers-$inte
+          make particle-id-$pids
+          make clean
+          make -j 4
+          done ; done
+          # test without mpi
+          make use-mpi-no
+          make clean
+          make -j 4
+
   build-docs:
     description: "Test the docs build."
     steps:
@@ -155,6 +196,33 @@ jobs:
           skipfile: notafile
           flags: --clobber
 
+  test-compile-options:
+    docker:
+      - image: circleci/python:3.7.2
+
+    working_directory: ~/enzo-dev
+
+    steps:
+      - checkout
+      - set-env
+
+      - restore_cache:
+          name: "Restore dependencies cache."
+          key: dependencies-v1
+
+      - install-dependencies
+
+      - save_cache:
+          name: "Save dependencies cache"
+          key: dependencies-v1
+          paths:
+            - ~/.cache/pip
+            - ~/venv
+            - ~/local
+
+      - install-grackle
+      - compile-test
+
   docs-build:
     docker:
       - image: circleci/python:3.7.2
@@ -171,5 +239,6 @@ workflows:
 
    tests:
      jobs:
+       - test-compile-options
        - test-suite
        - docs-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,8 +137,15 @@ commands:
           make clean
           make -j 4 || (make show-config ; exit 1)
           done ; done
+          make integers-64
+          make particle-id-64
           # test without mpi
           make use-mpi-no
+          make clean
+          make -j 4 || (make show-config ; exit 1)
+          make use-mpi-yes
+          # test ray-tracing
+          make use-photon-no
           make clean
           make -j 4 || (make show-config ; exit 1)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ commands:
           make precision-$prec
           make particles-$part
           make clean
-          make -j 4
+          make -j 4 || make show-config
           done ; done
           # return this to default
           make precision-64
@@ -135,12 +135,12 @@ commands:
           make integers-$inte
           make particle-id-$pids
           make clean
-          make -j 4
+          make -j 4 || make show-config
           done ; done
           # test without mpi
           make use-mpi-no
           make clean
-          make -j 4
+          make -j 4 || make show-config
 
   build-docs:
     description: "Test the docs build."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ commands:
           make precision-$prec
           make particles-$part
           make clean
-          'make -j 4 || (make show-config ; exit 1)'
+          make -j 4 || (make show-config ; exit 1)
           done ; done
           # return this to default
           make precision-64
@@ -135,12 +135,12 @@ commands:
           make integers-$inte
           make particle-id-$pids
           make clean
-          'make -j 4 || (make show-config ; exit 1)'
+          make -j 4 || (make show-config ; exit 1)
           done ; done
           # test without mpi
           make use-mpi-no
           make clean
-          'make -j 4 || (make show-config ; exit 1)'
+          make -j 4 || (make show-config ; exit 1)
 
   build-docs:
     description: "Test the docs build."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,6 @@ commands:
           ./configure
           cd src/enzo
           make machine-linux-gnu
-          make load-config-test-suite
           # test various baryon/particle precisions
           for prec in 32 64
           do for part in 32 64 128

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,8 @@ commands:
           for prec in 32 64
           do for part in 32 64 128
           do
-          if [ $prec == $part ]; then
+          # skip the test-suite configuration
+          if [[ $prec == 64 && $part == 64 ]]; then
           continue
           fi
           make precision-$prec
@@ -122,12 +123,14 @@ commands:
           make -j 4
           done ; done
           # return this to default
+          make precision-64
           make particles-64
           # test various integer/particle-id precisions
           for inte in 32 64
           do for pids in 32 64
           do
-          if [ $inte == $pids ]; then
+          # skip the test-suite configuration
+          if [[ $inte == 32 && $pids == 32 ]]; then
           continue
           fi
           make integers-$inte

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,6 @@ commands:
       - run: |
           source $BASH_ENV
           source $HOME/venv/bin/activate
-          alias build-enzo='make -j 4 || (make show-config ; exit 1)'
           ./configure
           cd src/enzo
           make machine-linux-gnu
@@ -120,7 +119,7 @@ commands:
           make precision-$prec
           make particles-$part
           make clean
-          build-enzo
+          'make -j 4 || (make show-config ; exit 1)'
           done ; done
           # return this to default
           make precision-64
@@ -136,12 +135,12 @@ commands:
           make integers-$inte
           make particle-id-$pids
           make clean
-          build-enzo
+          'make -j 4 || (make show-config ; exit 1)'
           done ; done
           # test without mpi
           make use-mpi-no
           make clean
-          build-enzo
+          'make -j 4 || (make show-config ; exit 1)'
 
   build-docs:
     description: "Test the docs build."

--- a/src/enzo/ActiveParticle_RadiationParticle.C
+++ b/src/enzo/ActiveParticle_RadiationParticle.C
@@ -401,6 +401,7 @@ int* ActiveParticleType_RadiationParticle::GetGridIndices(FLOAT *position, FLOAT
 
 void ActiveParticleType_RadiationParticle::SetRadiationDefaults()
 {
+#ifdef TRANSFER
   if (RadiativeTransfer == TRUE) {
      
     if(RadiativeTransferInitialHEALPixLevel == 0)
@@ -426,6 +427,7 @@ void ActiveParticleType_RadiationParticle::SetRadiationDefaults()
     
   }
   return;
+#endif
 }
 
 bool ActiveParticleType_RadiationParticle::IsARadiationSource(FLOAT Time)

--- a/src/enzo/ConvertParticles2ActiveParticles.C
+++ b/src/enzo/ConvertParticles2ActiveParticles.C
@@ -149,11 +149,13 @@ int ConvertParticles2ActiveParticles(char *ParameterFile,
 	Masterarray[i] = 1;
       }
     }
+#ifdef USE_MPI
   MPI_Allreduce(&numtypes, &global_active_particles, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
   MPI_Allreduce(Masterarray, RMasterarray, MAX_ACTIVE_PARTICLE_TYPES, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
   MPI_Barrier(MPI_COMM_WORLD);
   if(MyProcessorNumber == ROOT_PROCESSOR)
     printf("%s: Number of particles found = %d\n", __FUNCTION__, global_active_particles);
+#endif
 
 #if DEBUG
   /* Now lets collect up the active particle types */
@@ -197,10 +199,12 @@ int ConvertParticles2ActiveParticles(char *ParameterFile,
 
   }
 
+#ifdef USE_MPI
   MPI_Allreduce(&TotalNumberOfNewParticles, &GlobalTotalNumberOfNewParticles, 1, MPI_INT, MPI_SUM, 
 		MPI_COMM_WORLD);
   if(GlobalTotalNumberOfNewParticles && MyProcessorNumber == ROOT_PROCESSOR)
     printf("%s: TotalNumberOfNewParticles = %d\n", __FUNCTION__, GlobalTotalNumberOfNewParticles);
+#endif
   /* 
    * The new active particle types have now been created and the star objects destroyed.
    * Write the particles and active particles back to disk
@@ -214,9 +218,9 @@ int ConvertParticles2ActiveParticles(char *ParameterFile,
   return SUCCESS;
 }
 
-
 void CollectParticleTypes(char **active_particle_types, int global_active_particles)
 {
+#ifdef USE_MPI
   Eint32 my_gsize = 0;
   char **ap_types;
   char **ap_types2;
@@ -270,4 +274,5 @@ void CollectParticleTypes(char **active_particle_types, int global_active_partic
   }
  
   return;
+#endif
 }

--- a/src/enzo/Grid.h
+++ b/src/enzo/Grid.h
@@ -635,7 +635,7 @@ gradient force to gravitational force for one-zone collapse test. */
 
 /* Debugging support. */
 
-   int DebugCheck(char *message = "Debug");
+   int DebugCheck(const char *message = "Debug");
 
 #ifdef EMISSIVITY
    /* define function prototype as a grid member function */

--- a/src/enzo/Grid_DebugCheck.C
+++ b/src/enzo/Grid_DebugCheck.C
@@ -32,7 +32,7 @@
 #define DEBUG_CHECK_OFF
 #define TRACE_OFF
  
-int grid::DebugCheck(char *message)
+int grid::DebugCheck(const char *message)
 {
  
 #ifdef TRACE_ON

--- a/src/enzo/Make.config.targets
+++ b/src/enzo/Make.config.targets
@@ -384,14 +384,14 @@ machine-%: suggest-clean
 
 load-config-%:
 	@if [ -e $(HOME)/.enzo/Make.settings.$* ]; then \
-           @tmp=.config.temp; \
+           tmp=.config.temp; \
 	   cat $(HOME)/.enzo/Make.settings.$* > $(MAKE_CONFIG_OVERRIDE); \
            echo; \
            echo "   CONFIG SETTINGS: $*"; \
 	   $(MAKE) show-config; \
 	   $(MAKE) suggest-clean; \
 	elif [ -e Make.settings.$* ]; then \
-           @tmp=.config.temp; \
+           tmp=.config.temp; \
 	   cat Make.settings.$* > $(MAKE_CONFIG_OVERRIDE); \
            echo; \
            echo "   CONFIG SETTINGS: $*"; \

--- a/src/enzo/Make.mach.linux-gnu
+++ b/src/enzo/Make.mach.linux-gnu
@@ -13,7 +13,7 @@
 #
 #=======================================================================
 
-MACH_TEXT  = Use apt-get to install csh libhdf5-serial-dev gfortran openmpi-bin libopenmpi-dev
+MACH_TEXT  = Use apt-get to install libhdf5-serial-dev gfortran openmpi-bin libopenmpi-dev
 MACH_VALID = 1
 MACH_FILE  = Make.mach.linux-gnu
 

--- a/src/enzo/ParticleAttributeHandler.h
+++ b/src/enzo/ParticleAttributeHandler.h
@@ -19,7 +19,9 @@
 #define __PARTICLE_ATTRIBUTE_HANDLER_H
 
 /* http://www.gamedev.net/topic/474803-c-template-pointer-to-member/ */
+#ifdef USE_MPI
 #include <mpi.h>
+#endif
 #include <hdf5.h>
 class ActiveParticleType;
 

--- a/src/enzo/PhotonPackage.h
+++ b/src/enzo/PhotonPackage.h
@@ -57,7 +57,7 @@ public:
     for (int dim = 0; dim < 3; dim++) 
       r[dim] = SourcePosition[dim] + u[dim] * Radius;
     printf("Photons = %g, Type = %"ISYM", Radius = %"PSYM"\n", Photons, Type, Radius);
-    printf("ipix = %lld, level = %"ISYM"\n", ipix, level);
+    printf("ipix = %lld, level = %ld\n", ipix, level);
     printf("normal = %"PSYM" %"PSYM" %"PSYM"\n", u[0], u[1], u[2]);
     printf("SourcePosition = %"PSYM" %"PSYM" %"PSYM"\n",
 	   SourcePosition[0], SourcePosition[1], SourcePosition[2]);

--- a/src/enzo/ReadStarParticleData.C
+++ b/src/enzo/ReadStarParticleData.C
@@ -25,6 +25,7 @@
 
 // defined in Grid_ReadHierarchyInformationHDF5.C 
 int HDF5_ReadAttribute(hid_t group_id, const char *AttributeName, int &Attribute, FILE *log_fptr);
+int HDF5_ReadAttribute(hid_t group_id, const char *AttributeName, PINT &Attribute, FILE *log_fptr);
 
 int ReadStarParticleData(FILE *fptr, hid_t Hfile_id, FILE *log_fptr)
 {
@@ -52,7 +53,7 @@ int ReadStarParticleData(FILE *fptr, hid_t Hfile_id, FILE *log_fptr)
                  &NumberOfActiveParticles) != 1) {
         //      ENZO_FAIL("Error reading NumberOfActiveParticles.\n");
       }
-      if (fscanf(fptr, "NextActiveParticleID = %"ISYM"\n",
+      if (fscanf(fptr, "NextActiveParticleID = %"PISYM"\n",
                  &NextActiveParticleID) != 1) {
         //      ENZO_FAIL("Error reading NumberOfActiveParticles.\n");
       }

--- a/src/enzo/WriteHDF5HierarchyFile.C
+++ b/src/enzo/WriteHDF5HierarchyFile.C
@@ -32,9 +32,7 @@ int SetGlobalGridID(int &GlobalID, HierarchyEntry *Grid);
 // the following HDF5 helper routines are defined in
 // Grid_WriteHierarchyInformationHDF5.C
 int HDF5_WriteAttribute(hid_t group_id, const char *AttributeName, int Attribute, FILE *log_fptr);
-#ifdef SMALL_INTS
-int HDF5_WriteAttribute(hid_t group_id, const char *AttributeName, Eint64 Attribute, FILE *log_fptr);
-#endif
+int HDF5_WriteAttribute(hid_t group_id, const char *AttributeName, PINT Attribute, FILE *log_fptr);
 int HDF5_WriteAttribute(hid_t group_id, const char *AttributeName, FLOAT Attribute, FILE *log_fptr);
 int HDF5_WriteDataset(hid_t group_id, const char *DatasetName, int *Dataset, int NumberOfElements, FILE *log_fptr);
 

--- a/src/enzo/WriteHDF5HierarchyFile.C
+++ b/src/enzo/WriteHDF5HierarchyFile.C
@@ -101,7 +101,7 @@ int WriteHDF5HierarchyFile(char *base_name, HierarchyEntry *TopGrid, TopGridData
   // open the file
   if (io_log) fprintf(log_fptr, "Calling H5Fcreate with Name = %s\n", FileName);
   file_id = H5Fcreate(FileName, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-  if (io_log) fprintf(log_fptr, "H5Fcreate id: %"ISYM"\n", file_id);
+  if (io_log) fprintf(log_fptr, "H5Fcreate id: %d\n", file_id);
 
   
   // Calculate CurrentRedshift and add as attribute (if Cosmology)


### PR DESCRIPTION
I added a couple nested loops to test different combos of baryon/particle precision and integers/particle id precision. So to not do too many, I skip the combinations where the precision is the same. There is also a check to see if Enzo compiles without mpi.