### PR TITLE
Added JOSS paper to enzo-dev repository

### DIFF
--- a/method-paper-joss-2019/LICENSE
+++ b/method-paper-joss-2019/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2019, enzo-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/method-paper-joss-2019/README.md
+++ b/method-paper-joss-2019/README.md
@@ -1,0 +1,22 @@
+# enzo-method-paper-JOSS
+
+Enzo method paper for submission to the [Journal of Open Source Science](https://joss.theoj.org/).
+
+[Paper submission instructions](https://joss.readthedocs.io/en/latest/submitting.html) -
+this link also includes formatting instructions.
+
+[Review criteria](https://joss.readthedocs.io/en/latest/review_criteria.html)
+
+
+
+From the JOSS website:  JOSS welcomes submissions from broadly diverse research areas. For this reason, we require that authors include in the paper some sentences that would explain the software functionality and domain of use to a non-specialist reader. Your submission should probably be somewhere between 250-1000 words.
+
+In addition, your paper should include:
+
+A list of the authors of the software and their affiliations
+A summary describing the high-level functionality and purpose of the software for a diverse, non-specialist audience
+A clear statement of need that illustrates the purpose of the software
+A list of key references including a link to the software archive
+Mentions (if applicable) of any ongoing research projects using the software or recent scholarly publications enabled by it
+Acknowledgement of any financial support
+As this short list shows, JOSS papers are only permitted to contain a limited set of metadata (see header below), Statement of Need, Summary, Acknowledgements, and References sections. You can see an example accepted paper here. Given this paper format, a “full length” paper is not permitted, e.g., software documentation such as API (Application Programming Interface) functionality should not be in the paper and instead should be outlined in the software documentation.

--- a/method-paper-joss-2019/paper.bib
+++ b/method-paper-joss-2019/paper.bib
@@ -1,0 +1,506 @@
+@online{EnzoGitRepo,
+  author = {Enzo Developers},
+  title = {Enzo GitHub repository},
+  year = 2019,
+  url = {https://github.com/enzo-project/enzo-dev},
+  urldate = {2019-07-19}
+}
+
+@online{EnzoReleaseNotes,
+  author = {Enzo Developers},
+  title = {Enzo Release Notes},
+  year = 2019,
+  url = {https://enzo-project.org/ReleaseNotes.html},
+  urldate = {2019-07-19}
+}
+
+@ARTICLE{EnzoMethodPaper2014,
+       author = {{Bryan}, Greg L. and {Norman}, Michael L. and {O'Shea}, Brian W. and
+         {Abel}, Tom and {Wise}, John H. and {Turk}, Matthew J. and
+         {Reynolds}, Daniel R. and {Collins}, David C. and {Wang}, Peng and
+         {Skillman}, Samuel W. and {Smith}, Britton and {Harkness}, Robert P. and
+         {Bordner}, James and {Kim}, Ji-hoon and {Kuhlen}, Michael and
+         {Xu}, Hao and {Goldbaum}, Nathan and {Hummels}, Cameron and
+         {Kritsuk}, Alexei G. and {Tasker}, Elizabeth and {Skory}, Stephen and
+         {Simpson}, Christine M. and {Hahn}, Oliver and {Oishi}, Jeffrey S. and
+         {So}, Geoffrey C. and {Zhao}, Fen and {Cen}, Renyue and {Li}, Yuan and
+         {Enzo Collaboration}},
+        title = "{ENZO: An Adaptive Mesh Refinement Code for Astrophysics}",
+      journal = {The Astrophysical Journal Supplements},
+     keywords = {hydrodynamics, methods: numerical, Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = "2014",
+        month = "Apr",
+       volume = {211},
+       number = {2},
+          eid = {19},
+        pages = {19},
+          doi = {10.1088/0067-0049/211/2/19},
+archivePrefix = {arXiv},
+       eprint = {1307.2265},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2014ApJS..211...19B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{WiseNature2019,
+       author = {{Wise}, John H. and {Regan}, John A. and {O'Shea}, Brian W. and
+         {Norman}, Michael L. and {Downes}, Turlough P. and {Xu}, Hao},
+        title = "{Formation of massive black holes in rapidly growing pre-galactic gas clouds}",
+      journal = {\nat},
+     keywords = {Astrophysics - Astrophysics of Galaxies},
+         year = "2019",
+        month = "Jan",
+       volume = {566},
+       number = {7742},
+        pages = {85-88},
+          doi = {10.1038/s41586-019-0873-4},
+archivePrefix = {arXiv},
+       eprint = {1901.07563},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019Natur.566...85W},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{SmithPop2Prime2015,
+       author = {{Smith}, Britton D. and {Wise}, John H. and {O'Shea}, Brian W. and
+         {Norman}, Michael L. and {Khochfar}, Sadegh},
+        title = "{The first Population II stars formed in externally enriched mini-haloes}",
+      journal = {\mnras},
+     keywords = {hydrodynamics, radiative transfer, methods: numerical, galaxies: star formation, Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
+         year = "2015",
+        month = "Sep",
+       volume = {452},
+       number = {3},
+        pages = {2822-2836},
+          doi = {10.1093/mnras/stv1509},
+archivePrefix = {arXiv},
+       eprint = {1504.07639},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2015MNRAS.452.2822S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+@ARTICLE{OSheaLuminosity2015,
+       author = {{O'Shea}, Brian W. and {Wise}, John H. and {Xu}, Hao and
+         {Norman}, Michael L.},
+        title = "{Probing the Ultraviolet Luminosity Function of the Earliest Galaxies with the Renaissance Simulations}",
+      journal = {\apjl},
+     keywords = {galaxies: evolution, galaxies: formation, galaxies: high-redshift, Astrophysics - Astrophysics of Galaxies},
+         year = "2015",
+        month = "Jul",
+       volume = {807},
+       number = {1},
+          eid = {L12},
+        pages = {L12},
+          doi = {10.1088/2041-8205/807/1/L12},
+archivePrefix = {arXiv},
+       eprint = {1503.01110},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2015ApJ...807L..12O},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{PeeplesFOGGIE2019,
+       author = {{Peeples}, Molly S. and {Corlies}, Lauren and {Tumlinson}, Jason and
+         {O'Shea}, Brian W. and {Lehner}, Nicolas and {O'Meara}, John M. and
+         {Howk}, J. Christopher and {Earl}, Nicholas and {Smith}, Britton D. and
+         {Wise}, John H. and {Hummels}, Cameron B.},
+        title = "{Figuring Out Gas \&amp; Galaxies in Enzo (FOGGIE). I. Resolving Simulated Circumgalactic Absorption at 2 {\ensuremath{\leq}} z {\ensuremath{\leq}} 2.5}",
+      journal = {\apj},
+     keywords = {galaxies: evolution, hydrodynamics, intergalactic medium, quasars: absorption lines, Astrophysics - Astrophysics of Galaxies},
+         year = "2019",
+        month = "Mar",
+       volume = {873},
+       number = {2},
+          eid = {129},
+        pages = {129},
+          doi = {10.3847/1538-4357/ab0654},
+archivePrefix = {arXiv},
+       eprint = {1810.06566},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019ApJ...873..129P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{MeeceAGN2017,
+       author = {{Meece}, Gregory R. and {Voit}, G. Mark and {O'Shea}, Brian W.},
+        title = "{Triggering and Delivery Algorithms for AGN Feedback}",
+      journal = {\apj},
+     keywords = {galaxies: active, galaxies: clusters: intracluster medium, galaxies: ISM, galaxies: jets, X-rays: galaxies: clusters, Astrophysics - Astrophysics of Galaxies},
+         year = "2017",
+        month = "Jun",
+       volume = {841},
+       number = {2},
+          eid = {133},
+        pages = {133},
+          doi = {10.3847/1538-4357/aa6fb1},
+archivePrefix = {arXiv},
+       eprint = {1603.03674},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ApJ...841..133M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{SalemCRCGM2016,
+       author = {{Salem}, Munier and {Bryan}, Greg L. and {Corlies}, Lauren},
+        title = "{Role of cosmic rays in the circumgalactic medium}",
+      journal = {\mnras},
+     keywords = {methods: numerical, cosmic rays, galaxies: formation, Astrophysics - Astrophysics of Galaxies},
+         year = "2016",
+        month = "Feb",
+       volume = {456},
+       number = {1},
+        pages = {582-601},
+          doi = {10.1093/mnras/stv2641},
+archivePrefix = {arXiv},
+       eprint = {1511.05144},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2016MNRAS.456..582S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{LiAGN2017,
+       author = {{Li}, Yuan and {Ruszkowski}, Mateusz and {Bryan}, Greg L.},
+        title = "{AGN Heating in Simulated Cool-core Clusters}",
+      journal = {\apj},
+     keywords = {galaxies: active, galaxies: clusters: general, galaxies: clusters: intracluster medium, methods: numerical, Astrophysics - Astrophysics of Galaxies},
+         year = "2017",
+        month = "Oct",
+       volume = {847},
+       number = {2},
+          eid = {106},
+        pages = {106},
+          doi = {10.3847/1538-4357/aa88c1},
+archivePrefix = {arXiv},
+       eprint = {1611.05455},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ApJ...847..106L},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{GreteSGS2017,
+       author = {{Grete}, Philipp and {Vlaykov}, Dimitar G. and {Schmidt}, Wolfram and
+         {Schleicher}, Dominik R.~G.},
+        title = "{Comparative statistics of selected subgrid-scale models in large-eddy simulations of decaying, supersonic magnetohydrodynamic turbulence}",
+      journal = {\pre},
+     keywords = {Physics - Fluid Dynamics, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Physics - Computational Physics, Physics - Plasma Physics},
+         year = "2017",
+        month = "Mar",
+       volume = {95},
+       number = {3},
+          eid = {033206},
+        pages = {033206},
+          doi = {10.1103/PhysRevE.95.033206},
+archivePrefix = {arXiv},
+       eprint = {1703.00858},
+ primaryClass = {physics.flu-dyn},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017PhRvE..95c3206G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{KritsukTurb2018,
+       author = {{Kritsuk}, Alexei G. and {Flauger}, Raphael and {Ustyugov}, Sergey D.},
+        title = "{Dust-Polarization Maps for Local Interstellar Turbulence}",
+      journal = {\prl},
+     keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
+         year = "2018",
+        month = "Jul",
+       volume = {121},
+       number = {2},
+          eid = {021104},
+        pages = {021104},
+          doi = {10.1103/PhysRevLett.121.021104},
+archivePrefix = {arXiv},
+       eprint = {1711.11108},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018PhRvL.121b1104K},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@ARTICLE{BurkhartMolCloud2017,
+       author = {{Burkhart}, Blakesley and {Stalpes}, Kye and {Collins}, David C.},
+        title = "{The Razor{\textquoteright}s Edge of Collapse: The Transition Point from Lognormal to Power-Law Distributions in Molecular Clouds}",
+      journal = {\apjl},
+     keywords = {dust, extinction, galaxies: star formation, magnetohydrodynamics: MHD, Astrophysics - Astrophysics of Galaxies},
+         year = "2017",
+        month = "Jan",
+       volume = {834},
+       number = {1},
+          eid = {L1},
+        pages = {L1},
+          doi = {10.3847/2041-8213/834/1/L1},
+archivePrefix = {arXiv},
+       eprint = {1609.04409},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ApJ...834L...1B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{TurkPopIIIbinary2009,
+       author = {{Turk}, Matthew J. and {Abel}, Tom and {O'Shea}, Brian},
+        title = "{The Formation of Population III Binaries from Cosmological Initial Conditions}",
+      journal = {Science},
+     keywords = {ASTRONOMY, Astrophysics - Cosmology and Extragalactic Astrophysics},
+         year = "2009",
+        month = "Jul",
+       volume = {325},
+       number = {5940},
+        pages = {601},
+          doi = {10.1126/science.1173540},
+archivePrefix = {arXiv},
+       eprint = {0907.2919},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2009Sci...325..601T},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{ChiakiPop3to2_2019,
+   author = {{Chiaki}, G. and {Wise}, J.~H.},
+    title = "{Seeding the second star: enrichment from population III, dust evolution, and cloud collapse}",
+  journal = {\mnras},
+archivePrefix = "arXiv",
+   eprint = {1808.09515},
+ keywords = {stars: formation, stars: low-mass, stars: Population II, stars: Population III, ISM: abundances, galaxies: evolution},
+     year = 2019,
+    month = jan,
+   volume = 482,
+    pages = {3933-3949},
+      doi = {10.1093/mnras/sty2984},
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2019MNRAS.482.3933C},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{NormanReion2018,
+      author = {{Norman}, Michael L. and {Chen}, Pengfei and {Wise}, John H. and
+        {Xu}, Hao},
+       title = "{Fully Coupled Simulation of Cosmic Reionization. III. Stochastic Early Reionization by the Smallest Galaxies}",
+     journal = {\apj},
+    keywords = {galaxies: formation, galaxies: high-redshift, methods: numerical, radiative transfer, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
+        year = "2018",
+       month = "Nov",
+      volume = {867},
+      number = {1},
+         eid = {27},
+       pages = {27},
+         doi = {10.3847/1538-4357/aae30b},
+archivePrefix = {arXiv},
+      eprint = {1705.00026},
+primaryClass = {astro-ph.CO},
+      adsurl = {https://urldefense.proofpoint.com/v2/url?u=https-3A__ui.adsabs.harvard.edu_abs_2018ApJ...867...27N&d=DwIGaQ&c=nE__W8dFE-shTxStwXtp0A&r=VDrf8WKLFBYOA2thausDmA&m=e3n4wVtMbm---Lm2ZER8R_wQaoFimk2tScTunQlPQ6s&s=Ox-pJC1Lz4RioIkp-AsEZcnzuhT_wTEnxE-VOHx7KYQ&e= },
+     adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{SmithGrackle2017,
+       author = {{Smith}, Britton D. and {Bryan}, Greg L. and {Glover}, Simon C.~O. and
+         {Goldbaum}, Nathan J. and {Turk}, Matthew J. and {Regan}, John and
+         {Wise}, John H. and {Schive}, Hsi-Yu and {Abel}, Tom and
+         {Emerick}, Andrew and {O'Shea}, Brian W. and {Anninos}, Peter and
+         {Hummels}, Cameron B. and {Khochfar}, Sadegh},
+        title = "{GRACKLE: a chemistry and cooling library for astrophysics}",
+      journal = {\mnras},
+     keywords = {astrochemistry, methods: numerical, galaxies: formation, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = "2017",
+        month = "Apr",
+       volume = {466},
+       number = {2},
+        pages = {2217-2234},
+          doi = {10.1093/mnras/stw3291},
+archivePrefix = {arXiv},
+       eprint = {1610.09591},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017MNRAS.466.2217S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@ARTICLE{SalemCRs2014,
+       author = {{Salem}, Munier and {Bryan}, Greg L.},
+        title = "{Cosmic ray driven outflows in global galaxy disc models}",
+      journal = {\mnras},
+     keywords = {methods: numerical, cosmic rays, galaxies: formation, Astrophysics - Cosmology and Nongalactic Astrophysics},
+         year = "2014",
+        month = "Feb",
+       volume = {437},
+       number = {4},
+        pages = {3312-3330},
+          doi = {10.1093/mnras/stt2121},
+archivePrefix = {arXiv},
+       eprint = {1307.6215},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2014MNRAS.437.3312S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{SimpsonKineticSN2015,
+       author = {{Simpson}, Christine M. and {Bryan}, Greg L. and {Hummels}, Cameron and
+         {Ostriker}, Jeremiah P.},
+        title = "{Kinetic Energy from Supernova Feedback in High-resolution Galaxy Simulations}",
+      journal = {\apj},
+     keywords = {galaxies: dwarf, galaxies: stellar content, hydrodynamics, ISM: supernova remnants, methods: numerical, Astrophysics - Astrophysics of Galaxies},
+         year = "2015",
+        month = "Aug",
+       volume = {809},
+       number = {1},
+          eid = {69},
+        pages = {69},
+          doi = {10.1088/0004-637X/809/1/69},
+archivePrefix = {arXiv},
+       eprint = {1410.3822},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2015ApJ...809...69S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{ButskyMagneticSN2017,
+       author = {{Butsky}, Iryna and {Zrake}, Jonathan and {Kim}, Ji-hoon and
+         {Yang}, Hung-I. and {Abel}, Tom},
+        title = "{Ab Initio Simulations of a Supernova-driven Galactic Dynamo in an Isolated Disk Galaxy}",
+      journal = {\apj},
+     keywords = {magnetic fields, magnetohydrodynamics: MHD, methods: numerical, turbulence, Astrophysics - Astrophysics of Galaxies},
+         year = "2017",
+        month = "Jul",
+       volume = {843},
+       number = {2},
+          eid = {113},
+        pages = {113},
+          doi = {10.3847/1538-4357/aa799f},
+archivePrefix = {arXiv},
+       eprint = {1610.08528},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ApJ...843..113B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{LiFuzzyDM2019,
+       author = {{Li}, Xinyu and {Hui}, Lam and {Bryan}, Greg L.},
+        title = "{Numerical and perturbative computations of the fuzzy dark matter model}",
+      journal = {\prd},
+     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, General Relativity and Quantum Cosmology, High Energy Physics - Phenomenology, High Energy Physics - Theory},
+         year = "2019",
+        month = "Mar",
+       volume = {99},
+       number = {6},
+          eid = {063509},
+        pages = {063509},
+          doi = {10.1103/PhysRevD.99.063509},
+archivePrefix = {arXiv},
+       eprint = {1810.01915},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019PhRvD..99f3509L},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{SchmidtDrivenTurbulence2009,
+       author = {{Schmidt}, W. and {Federrath}, C. and {Hupp}, M. and {Kern}, S. and
+         {Niemeyer}, J.~C.},
+        title = "{Numerical simulations of compressively driven interstellar turbulence. I. Isothermal gas}",
+      journal = {\aap},
+     keywords = {hydrodynamics, turbulence, methods: numerical, ISM: kinematics and dynamics, Astrophysics},
+         year = "2009",
+        month = "Jan",
+       volume = {494},
+       number = {1},
+        pages = {127-145},
+          doi = {10.1051/0004-6361:200809967},
+archivePrefix = {arXiv},
+       eprint = {0809.1321},
+ primaryClass = {astro-ph},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2009A&A...494..127S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{ReganRiseSMS2018,
+       author = {{Regan}, John A. and {Downes}, Turlough P.},
+        title = "{Rise of the first supermassive stars}",
+      journal = {\mnras},
+     keywords = {cosmology: theory, methods: numerical, black hole physics, Astrophysics - Astrophysics of Galaxies},
+         year = "2018",
+        month = "Aug",
+       volume = {478},
+       number = {4},
+        pages = {5037-5049},
+          doi = {10.1093/mnras/sty1289},
+archivePrefix = {arXiv},
+       eprint = {1803.04527},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018MNRAS.478.5037R},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{LiISM2017,
+       author = {{Li}, Miao and {Bryan}, Greg L. and {Ostriker}, Jeremiah P.},
+        title = "{Quantifying Supernovae-driven Multiphase Galactic Outflows}",
+      journal = {\apj},
+     keywords = {galaxies: formation, galaxies: ISM, hydrodynamics, ISM: kinematics and dynamics, ISM: structure, Astrophysics - Astrophysics of Galaxies},
+         year = "2017",
+        month = "Jun",
+       volume = {841},
+       number = {2},
+          eid = {101},
+        pages = {101},
+          doi = {10.3847/1538-4357/aa7263},
+archivePrefix = {arXiv},
+       eprint = {1610.08971},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ApJ...841..101L},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{GoldbaumDiskGalaxies2016,
+       author = {{Goldbaum}, Nathan J. and {Krumholz}, Mark R. and {Forbes}, John C.},
+        title = "{Mass Transport and Turbulence in Gravitationally Unstable Disk Galaxies. II: The Effects of Star Formation Feedback}",
+      journal = {\apj},
+     keywords = {galaxies: evolution, galaxies: kinematics and dynamics, galaxies: spiral, ISM: kinematics and dynamics, ISM: structure, Astrophysics - Astrophysics of Galaxies},
+         year = "2016",
+        month = "Aug",
+       volume = {827},
+       number = {1},
+          eid = {28},
+        pages = {28},
+          doi = {10.3847/0004-637X/827/1/28},
+archivePrefix = {arXiv},
+       eprint = {1605.00646},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2016ApJ...827...28G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{FujimotoGCM2016,
+       author = {{Fujimoto}, Yusuke and {Bryan}, Greg L. and {Tasker}, Elizabeth J. and
+         {Habe}, Asao and {Simpson}, Christine M.},
+        title = "{GMC evolution in a barred spiral galaxy with star formation and thermal feedback}",
+      journal = {\mnras},
+     keywords = {hydrodynamics, methods: numerical, ISM: clouds, ISM: structure, galaxies: stars formation, galaxies: structure, Astrophysics - Astrophysics of Galaxies},
+         year = "2016",
+        month = "Sep",
+       volume = {461},
+       number = {2},
+        pages = {1684-1700},
+          doi = {10.1093/mnras/stw1461},
+archivePrefix = {arXiv},
+       eprint = {1606.04981},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2016MNRAS.461.1684F},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{HristovSNDeflagration2018,
+       author = {{Hristov}, Boyan and {Collins}, David C. and {Hoeflich}, Peter and
+         {Weatherford}, Charles A. and {Diamond}, Tiara R.},
+        title = "{Magnetohydrodynamical Effects on Nuclear Deflagration Fronts in Type Ia Supernovae}",
+      journal = {\apj},
+     keywords = {instabilities, magnetic fields, magnetohydrodynamics: MHD, turbulence, white dwarfs, Astrophysics - Solar and Stellar Astrophysics, Astrophysics - High Energy Astrophysical Phenomena},
+         year = "2018",
+        month = "May",
+       volume = {858},
+       number = {1},
+          eid = {13},
+        pages = {13},
+          doi = {10.3847/1538-4357/aab7f2},
+archivePrefix = {arXiv},
+       eprint = {1711.11103},
+ primaryClass = {astro-ph.SR},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018ApJ...858...13H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+

--- a/method-paper-joss-2019/paper.md
+++ b/method-paper-joss-2019/paper.md
@@ -1,0 +1,290 @@
+---
+title: 'ENZO: An Adaptive Mesh Refinement Code for Astrophysics (Version 2.6)'
+tags:
+  - adaptive mesh refinement
+  - astrophysics
+  - galaxy formation 
+authors:
+  - name: Corey Brummel-Smith
+    orcid: 0000-0001-6204-5181
+    affiliation: 4
+  - name: Greg Bryan
+    orcid: 0000-0003-2630-9228
+    affiliation: "1, 2"
+  - name: Iryna Butsky
+    orcid: 0000-0003-1257-5007
+    affiliation: 14
+  - name: Lauren Corlies
+    orcid: 0000-0002-0646-1540
+    affiliation: "5, 6"
+  - name: Andrew Emerick
+    orcid: 0000-0003-2807-328X
+    affiliation: "1, 10"
+  - name: John Forbes
+    orcid: 0000-0002-1975-4449
+    affiliation: 19
+  - name: Yusuke Fujimoto
+    orchid: 0000-0002-2107-1460
+    affiliation: 34
+  - name: Nathan J. Goldbaum
+    orcid: 0000-0001-5557-267X
+    affiliation: 15
+  - name: Philipp Grete
+    orcid: 0000-0003-3555-9886
+    affiliation: 3
+  - name: Cameron B. Hummels
+    orcid: 0000-0002-3817-8133
+    affiliation: 8
+  - name: Ji-hoon Kim
+    orcid: 0000-0003-4464-1160
+    affiliation: 18
+  - name: Daegene Koh
+    orcid: 0000-0002-3546-5786
+    affiliation: "24, 25"
+  - name: Miao Li
+    orcid: 0000-0003-0773-582X
+    affiliation: 2
+  - name: Yuan Li
+    orcid: 0000-0001-5262-6150
+    affiliation: 29
+  - name: Xinyu Li
+    orcid: 0000-0003-0750-3543
+    affiliation: 1
+  - name: Brian O'Shea
+    orcid: 0000-0002-2786-0348
+    affiliation: "3, 16"
+  - name: Molly S. Peeples
+    orcid: 0000-0003-1455-8788
+    affiliation: "5, 7"
+  - name: John A. Regan
+    orcid: 0000-0001-9072-6427
+    affiliation: 11
+  - name: Munier Salem
+    orcid: 0000-0002-0197-526X
+    affiliation: 1
+  - name: Wolfram Schmidt
+    orcid: 0000-0001-5233-8087
+    affiliation: 33
+  - name: Christine M. Simpson
+    orcid: 0000-0001-9985-1814
+    affiliation: "21, 22"
+  - name: Britton D. Smith
+    orcid: 0000-0002-6804-630X
+    affiliation: 9
+  - name: Jason Tumlinson
+    orcid: 0000-0002-7982-412X
+    affiliation: "5, 7"
+  - name: Matthew J. Turk
+    orcid: 0000-0002-5294-0198
+    affiliation: 15
+  - name: John H. Wise
+    orcid: 0000-0003-1173-8847
+    affiliation: 4
+  - name: Tom Abel
+    orcid: 0000-0002-5969-1251
+    affiliation: "24, 25"
+  - name: James Bordner
+    orcid: 0000-0002-2625-5787
+    affiliation: 20
+  - name: Renyue Cen
+    orcid: 0000-0001-8531-9536
+    affiliation: 27
+  - name: David C. Collins
+    orcid: 0000-0001-6661-2243 
+    affiliation: 12
+  - name: Brian Crosby
+    orcid: 0000-0003-0179-874X
+    affiliation: 3
+  - name: Philipp Edelmann
+    orcid: 0000-0001-7019-9578
+    affiliation: 32
+  - name: Oliver Hahn
+    orcid: 0000-0001-9440-1152
+    affiliation: 31
+  - name: Robert Harkness
+    affiliation: 20
+  - name: Elizabeth Harper-Clark
+    affiliation: 36
+  - name: Shuo Kong
+    affiliation: 37
+  - name: Alexei G. Kritsuk
+    orcid: 0000-0002-6554-1161
+    affiliation: 20
+  - name: Michael Kuhlen
+    affiliation: 29
+  - name: James Larrue
+    affiliation: 37
+  - name: Eve Lee
+    orcid: 0000-0002-1228-9820
+    affiliation: 37
+  - name: Greg Meece
+    affiliation: 3
+  - name: Michael L. Norman
+    orcid: 0000-0002-6622-8513
+    affiliation: "20, 23"
+  - name: Jeffrey S. Oishi
+    orcid: 0000-0001-8531-6570
+    affiliation: 13
+  - name: Pascal Paschos
+    affiliation: 20
+  - name: Carolyn Peruta
+    affiliation: 3
+  - name: Alex Razoumov
+    orcid: 0000-0003-4392-6826
+    affiliation: 35
+  - name: Daniel R. Reynolds
+    orcid: 0000-0002-0911-7841
+    affiliation: 26
+  - name: Devin Silvia
+    orcid: 0000-0002-4109-9313
+    affiliation: 16
+  - name: Samuel W. Skillman
+    orcid: 0000-0002-7626-522X
+    affiliation: 28
+  - name: Stephen Skory
+    affiliation: 30
+  - name: Geoffrey C So
+    affiliation: 20
+  - name: Elizabeth Tasker
+    orcid: 0000-0001-6692-612X
+    affiliation: 17
+  - name: Rick Wagner
+    orcid: 0000-0003-1291-5876
+    affiliation: 20
+  - name: Peng Wang
+    affiliation: 24
+  - name: Hao Xu
+    affiliation: 20
+  - name: Fen Zhao
+    affiliation: 24
+affiliations:
+ - name: Dept. of Astronomy, Columbia University
+   index: 1
+ - name: Center for Computational Astrophysics, Flatiron Institute
+   index: 2
+ - name: Dept. of Physics and Astronomy, Michigan State University
+   index: 3
+ - name: Center for Relativistic Astrophysics, School of Physics, Georgia Institute of Technology
+   index: 4
+ - name: Dept. of Physics and Astronomy, Johns Hopkins University
+   index: 5
+ - name: Large Synoptic Survey Telescope
+   index: 6
+ - name: Space Telescope Science Institute
+   index: 7
+ - name: California Institute of Technology
+   index: 8
+ - name: Royal Observatory, University of Edinburgh
+   index: 9 
+ - name: American Museum of Natural History
+   index: 10
+ - name: Center for Astrophysics and Relativity, Dublin City University
+   index: 11
+ - name: Dept. of Physics, Florida State University
+   index: 12
+ - name: Physics and Astronomy, Bates College
+   index: 13
+ - name: Dept. of Astronomy, University of Washington in Seattle
+   index: 14
+ - name: School of Information Sciences, University of Illinois, Urbana-Champaign
+   index: 15
+ - name: Department of Computational Mathematics, Science, and Engineering, Michigan State University
+   index: 16
+ - name: Institute of Space and Astronautical Science, Japan Aerospace Exploration Agency
+   index: 17
+ - name: Seoul National University, Korea
+   index: 18
+ - name: Center for Astrophysics, Harvard & Smithsonian
+   index: 19
+ - name: Center for Astrophysics and Space Sciences, University of California, San Diego
+   index: 20
+ - name: Enrico Fermi Institute, The University of Chicago
+   index: 21
+ - name: Department of Astronomy & Astrophysics, The University of Chicago
+   index: 22
+ - name: SDSC, University of California, San Diego
+   index: 23
+ - name: Kavli Institute for Particle Astrophysics and Cosmology, Stanford University
+   index: 24
+ - name: Department of Physics, Stanford University, Stanford
+   index: 25
+ - name: Department of Mathematics, Southern Methodist University
+   index: 26
+ - name: Department of Astrophysical Sciences, Princeton University
+   index: 27
+ - name: Descartes Labs
+   index: 28
+ - name: Theoretical Astrophysics Center, University of California Berkeley
+   index: 29
+ - name: OnSpot Data 
+   index: 30 
+ - name: Observatoire de la C'ote d'Azur
+   index: 31
+ - name: Max-Planck-Institut for Astrophysik
+   index: 32
+ - name: Hamburg Observatory, University of Hamburg
+   index: 33
+ - name: RSAA, Australian National University
+   index: 34
+ - name: Dept. of Astronomy & Physics, Saint Mary’s University, Halifax
+   index: 35
+ - name: Canadian Institute for Theoretical Astrophysics
+   index: 36
+ - name: No current affiliation
+   index: 37
+date: 2 August 2019
+bibliography: paper.bib
+---
+
+# Summary
+
+Enzo [@EnzoGitRepo] is a block-structured adaptive mesh refinement code that is widely used to simulate astrophysical fluid flows (primarily, but not exclusively, cosmological structure formation, star formation, and turbulence).  The code is a community project with dozens of users, and has contributed to hundreds of peer-reviewed publications in astrophysics, physics, and computer science.
+The code is Cartesian, can be run in one, two, and three dimensions, and supports a wide variety of physics including (magneto)hydrodynamics, the self-gravity of fluids and particles, cosmological expansion, primordial gas chemistry, optically thin radiative plasma cooling, radiation transport, conduction, and models for star formation, stellar feedback, and the feedback from supermassive black holes.
+
+Enzo's original method paper [@EnzoMethodPaper2014] was published in 2014, and documented Version 2.3.  This paper describes Enzo's most recent public release, Version 2.6 (released on August 2, 2019; see [@EnzoReleaseNotes]).  Since Version 2.3, there have been several new features added to the code:
+
+* Support for the Grackle chemistry and cooling library [@SmithGrackle2017]
+* Several new types of adaptive mesh refinement algorithms [@PeeplesFOGGIE2019]
+* Cosmic ray pressure, diffusion, and injection [@SalemCRs2014]
+* A stochastic forcing module (for driven turbulence calculations) [@SchmidtDrivenTurbulence2009]
+* A subgrid-scale turbulence modeling framework [@GreteSGS2017]
+* Kinetic supernova feedback [@SimpsonKineticSN2015]
+* Magnetic supernova feedback [@ButskyMagneticSN2017]
+* An "active particle" framework for complex particle types [@MeeceAGN2017; @ReganRiseSMS2018]
+* Fuzzy dark matter evolution [@LiFuzzyDM2019]
+* Many new code test problems
+* Automated regression testing on GitHub with CircleCI
+
+In addition, there are a much larger number of code enhancements and bug fixes.  A complete listing of new features, enhancements, and bug fixes for all code releases can be found at [@EnzoReleaseNotes].
+
+# Research with Enzo
+
+Enzo is used extensively in the astrophysics research community.  A few recent notable research areas that have benefited from the use of Enzo include:
+
+* Exploration of galaxy formation in the early universe [@SmithPop2Prime2015; @OSheaLuminosity2015; @WiseNature2019] 
+* Reionization of the universe [@NormanReion2018]
+* High resolution examination of the circumgalactic medium around Milky Way-like galaxies [@SalemCRCGM2016; @PeeplesFOGGIE2019]
+* The impact of supermassive black holes on the regulation of galaxy cluster cores [@LiAGN2017; @MeeceAGN2017]
+* Astrophysical turbulence [@GreteSGS2017; @KritsukTurb2018]
+* Star formation, both in a primordial context and in a Milky Way-type environment [@BurkhartMolCloud2017; @ChiakiPop3to2_2019]
+* The interstellar medium and its effect on galaxy behavior [@FujimotoGCM2016; @LiISM2017; @GoldbaumDiskGalaxies2016]
+* Supernova deflagration [@HristovSNDeflagration2018]
+
+# Acknowledgments
+
+The development of Enzo has been funded from a wide variety of sources.  The Enzo method paper [@EnzoMethodPaper2014] enumerates support through 2014.  Since then, Enzo development has been funded by 
+NASA grants NNX15AP39G (BWO), NNX17AG23G (JHW), NNX17AF87G (DCC),
+NNX15AB19G (GB), HST-AR-13261.01-A (BWO), HST-AR-13895 (JHW),
+HST-AR-14315.001-A (BWO), HST-AR-14326 (JHW), HST-AR-15012 (LC),
+NSF grants AST-1333360 (JHW), AST-1615955 (GB), AST-1514700 (BWO),
+AST-1517908 (BWO, MSP, LC, JT), AST-1614333 (JHW), AST-1615848 (BDS, MLN), PHY-1430152 (BWO),
+OAC-1835213 (GB, MLN, BWO, JHW), ACI-1516003 (MLN),
+AST-1616026 (DCC), AAG AST-1715133 (DCC), OAC-1810074,
+NSF Graduate Research Fellowship DGE 16-44869 (AE),
+the Blue Waters Graduate Fellowship, which was supported by NSF grants No. OCI-0725070 and No. ACI-1238993 and the State of Illinois (IB, AE, FG),
+Michigan State University internal funding (BWO),
+the Los Alamos National Laboratory Institute for Geophysics and Planetary Physics (BWO),
+and the Marie Skłodowska-Curie Grant – ‘SMARTSTARS’ – grant number 699941 (JAR).
+
+# References
+ 	


### PR DESCRIPTION
This PR moves the new (2019) Enzo method paper from its own repository into the main enzo repository, as required by the JOSS guidelines.