### PR TITLE
remove duplicate FAQ entry

### DIFF
--- a/doc/manual/source/index.rst
+++ b/doc/manual/source/index.rst
@@ -26,7 +26,7 @@ National Science Foundation.
    developer_guide/index.rst
    reference/index.rst
    presentations/index.rst
-   faq/index.rst
+
 
 Enzo Mailing Lists
 -----------------------


### PR DESCRIPTION
The FAQ chapter appears to be duplicated in the docs.  Once near the middle and again at the end.  

https://enzo.readthedocs.io/en/enzo-2.6/index.html

This removes the latter.
