### PR TITLE
[JOSS] Requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
           cd $HOME/grackle
           ./configure
           cd src/clib
-          make machine-ubuntu
+          make machine-linux-gnu
           make
           make install
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
           cd $HOME/grackle
           ./configure
           cd src/clib
-          make machine-linux-gnu
+          make machine-ubuntu
           make
           make install
 
@@ -91,7 +91,7 @@ commands:
             git checkout << parameters.tag >>
             ./configure
             cd src/enzo
-            make machine-linux-gnu
+            make machine-ubuntu
             make load-config-test-suite
             make clean
             make -j 4
@@ -107,7 +107,7 @@ commands:
           source $HOME/venv/bin/activate
           ./configure
           cd src/enzo
-          make machine-linux-gnu
+          make machine-ubuntu
           # test various baryon/particle precisions
           for prec in 32 64
           do for part in 32 64 128

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-= ENZO =
+# ENZO
 
 ENZO IS AN OPEN SOURCE CODE.  We encourage you to take it, inspect it, use it,
 and contribute back any changes you have made.  We strive to make the the Enzo
 community a community of *developers*.
 
-== RESOURCES ==
+## RESOURCES
 
 Enzo's main webpage is:
 
@@ -32,7 +32,23 @@ git version control system, we highly encourage you to upgrade to the
 version controlled source, as no support can be provided for archived
 ("tarball") sources.
 
-== DEVELOPERS ==
+## REQUIREMENTS
+
+Mandatory:
+
+- C/C++ and Fortan90 compiler
+- MPI (such as OpenMPI, MPICH, or IntelMPI) for multi-processor parallel jobs
+- [HDF5](https://www.hdfgroup.org/) (serial version) for data outputs
+
+Optional:
+
+- [yt](https://yt-project.org/) for data analysis and visualization (highly recommended)
+- [Grackle](https://github.com/grackle-project/grackle), a chemistry and radiative 
+cooling library with support for Enzo
+- [KROME](http://www.kromepackage.org/), a chemistry and microphysics library with
+support for Enzo
+
+## DEVELOPERS
 
 Many people have contributed to the development of Enzo -- here's just a short
 list of the people who have recently contributed, in alphabetical order:

--- a/src/enzo/Make.mach.linux-gnu
+++ b/src/enzo/Make.mach.linux-gnu
@@ -2,18 +2,33 @@
 #
 # FILE:        Make.mach.linux-gnu
 #
-# DESCRIPTION: Makefile settings for a machine running Ubuntu
+# DESCRIPTION: Makefile settings for a linux machine
 #
 # AUTHOR:      Rick Wagner (rick@ucsd.edu)
 #
-# DATE:        2008-09-16
+# DATE:        2008-09-16 (updated 2019-09-11)
 #
-# This configuration assumes that build-essentials, gfortran, 
-# OpenMPI and HDF5 have been installed using apt-get.
+# Depending on your linux distribution several packages need to be installed
+# to satisfy the minimum Enzo requirements (GNU compiler suite with
+# gfortran/gcc/g++, an MPI library for parallel runs, and HDF5 for data outputs).
+#
+# Sample environments
+#
+# Ubuntu/Debian: 
+# $ apt-get install build-essentials gfortran libhdf5-10 libopenmpi-dev openmpi-bin
+#
+# Fedora/Redhat:
+# $ yum install make automake gcc gcc-c++ gcc-gfortran kernel-devel openmpi openmpi-devel
+#
+# Arch Linux:
+# $ pacman -S base-devel gcc-fortran openmpi hdf5
 #
 #=======================================================================
 
-MACH_TEXT  = Use apt-get to install libhdf5-serial-dev gfortran openmpi-bin libopenmpi-dev
+MACH_TEXT  = Generic GNU/Linux machine file. Requires gfortran/gcc/g++, OpenMPI, and a \
+serial HDF5 library. Make sure to set the correct LOCAL_HDF5_INSTALL path in the \
+machine file (e.g., /usr for a system-wide installation or a custom path for local \
+installations).
 MACH_VALID = 1
 MACH_FILE  = Make.mach.linux-gnu
 
@@ -21,8 +36,9 @@ MACH_FILE  = Make.mach.linux-gnu
 # Install paths (local variables)
 #-----------------------------------------------------------------------
 
-LOCAL_GRACKLE_INSTALL = $(HOME)/local
-LOCAL_HYPRE_INSTALL = $(HOME)/local
+LOCAL_HDF5_INSTALL    = /PATH/TO/SERIAL-HDF5/INSTALL # mandatory
+LOCAL_GRACKLE_INSTALL = /PATH/TO/GRACKLE/INSTALL # optional
+LOCAL_HYPRE_INSTALL   = /PATH/TO/HYPRE/INSTALL   # optional
 
 #-----------------------------------------------------------------------
 # Compiler settings
@@ -78,7 +94,7 @@ MACH_OPT_AGGRESSIVE  = -O3 -g
 #-----------------------------------------------------------------------
 
 LOCAL_INCLUDES_MPI    = # MPI includes
-LOCAL_INCLUDES_HDF5   = -I/usr/include/hdf5/serial # HDF5 includes
+LOCAL_INCLUDES_HDF5   = -I$(LOCAL_HDF5_INSTALL) # HDF5 includes
 LOCAL_INCLUDES_HYPRE  = -I$(LOCAL_HYPRE_INSTALL)/include
 LOCAL_INCLUDES_PAPI   = # PAPI includes
 LOCAL_INCLUDES_GRACKLE = -I$(LOCAL_GRACKLE_INSTALL)/include
@@ -94,7 +110,7 @@ MACH_INCLUDES_GRACKLE  = $(LOCAL_INCLUDES_GRACKLE)
 #-----------------------------------------------------------------------
 
 LOCAL_LIBS_MPI    = # MPI libraries
-LOCAL_LIBS_HDF5   = -L/usr/lib/x86_64-linux-gnu/ -lhdf5_serial -lz
+LOCAL_LIBS_HDF5   = -L$(LOCAL_HDF5_INSTALL)/lib -lhdf5 -lz
 LOCAL_LIBS_HYPRE  = -L$(LOCAL_HYPRE_INSTALL)/lib -lHYPRE
 LOCAL_LIBS_PAPI   = # PAPI libraries
 LOCAL_LIBS_MACH   = -lgfortran # Machine-dependent libraries

--- a/src/enzo/Make.mach.ubuntu
+++ b/src/enzo/Make.mach.ubuntu
@@ -1,44 +1,28 @@
 #=======================================================================
 #
-# FILE:        Make.mach.linux-gnu
+# FILE:        Make.mach.ubuntu
 #
-# DESCRIPTION: Makefile settings for a linux machine
+# DESCRIPTION: Makefile settings for a machine running Ubuntu
 #
 # AUTHOR:      Rick Wagner (rick@ucsd.edu)
 #
-# DATE:        2008-09-16 (updated 2019-09-11)
+# DATE:        2008-09-16
 #
-# Depending on your linux distribution several packages need to be installed
-# to satisfy the minimum Enzo requirements (GNU compiler suite with
-# gfortran/gcc/g++, an MPI library for parallel runs, and HDF5 for data outputs).
-#
-# Sample environments
-#
-# Ubuntu/Debian (see also Make.mach.ubuntu): 
-# $ apt-get install build-essentials gfortran libhdf5-10 libopenmpi-dev openmpi-bin
-#
-# Fedora/Redhat:
-# $ yum install make automake gcc gcc-c++ gcc-gfortran kernel-devel openmpi openmpi-devel
-#
-# Arch Linux:
-# $ pacman -S base-devel gcc-fortran openmpi hdf5
+# This configuration assumes that build-essentials, gfortran, 
+# OpenMPI and HDF5 have been installed using apt-get.
 #
 #=======================================================================
 
-MACH_TEXT  = Generic GNU/Linux machine file. Requires gfortran/gcc/g++, OpenMPI, and a \
-serial HDF5 library. Make sure to set the correct LOCAL_HDF5_INSTALL path in the \
-machine file (e.g., /usr for a system-wide installation or a custom path for local \
-installations).
+MACH_TEXT  = Use apt-get to install libhdf5-serial-dev gfortran openmpi-bin libopenmpi-dev
 MACH_VALID = 1
-MACH_FILE  = Make.mach.linux-gnu
+MACH_FILE  = Make.mach.ubuntu
 
 #-----------------------------------------------------------------------
 # Install paths (local variables)
 #-----------------------------------------------------------------------
 
-LOCAL_HDF5_INSTALL    = /PATH/TO/SERIAL-HDF5/INSTALL # mandatory
-LOCAL_GRACKLE_INSTALL = /PATH/TO/GRACKLE/INSTALL # optional
-LOCAL_HYPRE_INSTALL   = /PATH/TO/HYPRE/INSTALL   # optional
+LOCAL_GRACKLE_INSTALL = $(HOME)/local
+LOCAL_HYPRE_INSTALL = $(HOME)/local
 
 #-----------------------------------------------------------------------
 # Compiler settings
@@ -94,7 +78,7 @@ MACH_OPT_AGGRESSIVE  = -O3 -g
 #-----------------------------------------------------------------------
 
 LOCAL_INCLUDES_MPI    = # MPI includes
-LOCAL_INCLUDES_HDF5   = -I$(LOCAL_HDF5_INSTALL) # HDF5 includes
+LOCAL_INCLUDES_HDF5   = -I/usr/include/hdf5/serial # HDF5 includes
 LOCAL_INCLUDES_HYPRE  = -I$(LOCAL_HYPRE_INSTALL)/include
 LOCAL_INCLUDES_PAPI   = # PAPI includes
 LOCAL_INCLUDES_GRACKLE = -I$(LOCAL_GRACKLE_INSTALL)/include
@@ -110,7 +94,7 @@ MACH_INCLUDES_GRACKLE  = $(LOCAL_INCLUDES_GRACKLE)
 #-----------------------------------------------------------------------
 
 LOCAL_LIBS_MPI    = # MPI libraries
-LOCAL_LIBS_HDF5   = -L$(LOCAL_HDF5_INSTALL)/lib -lhdf5 -lz
+LOCAL_LIBS_HDF5   = -L/usr/lib/x86_64-linux-gnu/ -lhdf5_serial -lz
 LOCAL_LIBS_HYPRE  = -L$(LOCAL_HYPRE_INSTALL)/lib -lHYPRE
 LOCAL_LIBS_PAPI   = # PAPI libraries
 LOCAL_LIBS_MACH   = -lgfortran # Machine-dependent libraries


### PR DESCRIPTION
Addresses #96 

Adds info on requirements already at the README level and make the instructions for GNU/Linux more generic.

I also renamed `README` to `README.md` and updated the content to use markdown so that it's properly rendered on GitHub.