### PR TITLE
[JOSS] Addressing several physics, AMR, and citation issues in Enzo docs

### DIFF
--- a/doc/manual/source/index.rst
+++ b/doc/manual/source/index.rst
@@ -11,8 +11,11 @@ grid-based hybrid code (hydro + N-Body) which is designed to do simulations of
 cosmological structure formation. Links to documentation and downloads for all
 versions of Enzo from 1.0 on are available. 
 
-Enzo development is supported by grants AST-0808184 and OCI-0832662 from the
-National Science Foundation. 
+Enzo development has been primarily supported by the US National Science
+Foundation, National Aeronautics and Space Administration, and Department
+of Energy.  In addition, significant funding has been contriubuted by
+a large number of academic institutions, private foundations, and other
+funding agencies across the globe. 
 
 .. toctree::
    :maxdepth: 2

--- a/doc/manual/source/index.rst
+++ b/doc/manual/source/index.rst
@@ -13,7 +13,7 @@ versions of Enzo from 1.0 on are available.
 
 Enzo development has been primarily supported by the US National Science
 Foundation, National Aeronautics and Space Administration, and Department
-of Energy.  In addition, significant funding has been contriubuted by
+of Energy.  In addition, significant funding has been contributed by
 a large number of academic institutions, private foundations, and other
 funding agencies across the globe. 
 

--- a/doc/manual/source/physics/adaptive_mesh.rst
+++ b/doc/manual/source/physics/adaptive_mesh.rst
@@ -13,7 +13,7 @@ grids" (with the ratio of resolutions typically, but not necessarily,
 being 2).  This method is distinct from cell-based AMR codes in that
 cells are aggregated into grids, and distinct from oct-tree block
 structured AMR in that the grids that are created can be of arbitrary
-size and aspect ratio (i.e., each grid dimension can differe, rather
+size and aspect ratio (i.e., each grid dimension can differ, rather
 than being a cube) and can be located at arbitrary locations within
 the parent grid rather than in octants of the parent grid.  Enzo does
 not implement the full Berger and Colella method - for the sake of

--- a/doc/manual/source/physics/adaptive_mesh.rst
+++ b/doc/manual/source/physics/adaptive_mesh.rst
@@ -1,0 +1,40 @@
+.. _adaptive_mesh:
+
+Adaptive Mesh Refinement
+========================
+
+Enzo's adaptive mesh implements a version of the `Berger and Colella (1989)
+<https://ui.adsabs.harvard.edu/abs/1989JCoPh..82...64B/abstract>`_
+block-structured AMR algorithm on a Cartesian mesh.  In this
+algorithm, cells that are flagged for refinement are combined into
+rectangular solid "child grid" patches with cells whose spatial resolution are
+an integer multiple more finely resolved than their coarser "parent
+grids" (with the ratio of resolutions typically, but not necessarily,
+being 2).  This method is distinct from cell-based AMR codes in that
+cells are aggretated into grids, and distinct from oct-tree block
+structured AMR in that the grids that are created can be of arbitrary
+size and aspect ratio (i.e., each grid dimension can differe, rather
+than being a cube) and can be located at arbitrary locations within
+the parent grid rather than in octants of the parent grid.  Enzo does
+not implement the full Berger and Colella method - for the sake of
+efficiency, it is restricted in the following ways:
+
+* Higher-resolution child grids must be contained completely within
+  their parent grids, rather than spanning multiple parent grids.
+  (Parent grids of level L are, however, allowed to have
+  multiple child grids of level L+1.)
+* The edges of child grids must align with the cell edges of parent
+  grids (which also implicitly requires that child grids align
+  with the edges of their parent grids).
+* All grids are aligned with the principle axes (x,y,z), and may not
+  be arbitrarily rotated with respect to those axes.
+
+Enzo implements time subcycling within its AMR, with every grid level L
+determining its own timestep and all grids at that level taking the
+same timestep.  This timestep is restricted so that the timestep at
+level L may not exceed the timestep at level L-1.
+The `Enzo method paper <https://ui.adsabs.harvard.edu/abs/2014ApJS..211...19B/abstract>`_ 
+describes the algorithm in more detail.
+
+The parameters controlling Enzo's grid hierarchy can be found in :ref:`hierarchy_control_parameters`.
+

--- a/doc/manual/source/physics/adaptive_mesh.rst
+++ b/doc/manual/source/physics/adaptive_mesh.rst
@@ -11,7 +11,7 @@ rectangular solid "child grid" patches with cells whose spatial resolution are
 an integer multiple more finely resolved than their coarser "parent
 grids" (with the ratio of resolutions typically, but not necessarily,
 being 2).  This method is distinct from cell-based AMR codes in that
-cells are aggretated into grids, and distinct from oct-tree block
+cells are aggregated into grids, and distinct from oct-tree block
 structured AMR in that the grids that are created can be of arbitrary
 size and aspect ratio (i.e., each grid dimension can differe, rather
 than being a cube) and can be located at arbitrary locations within

--- a/doc/manual/source/physics/gravity.rst
+++ b/doc/manual/source/physics/gravity.rst
@@ -10,7 +10,10 @@ to solve Poisson’s equation on the
 root grid on each timestep. The advantage of using this method is that
 it is fast, accurate, and naturally allows both periodic and isolated
 boundary conditions for the gravity, choices which are very common in
-astrophysics and cosmology. On subgrids, we interpolate the boundary
+astrophysics and cosmology (with isolated boundary conditions on the
+root grid being implemented with the `James (1977) method
+<https://doi.org/10.1016/0021-9991(77)90013-4>`_).
+On subgrids, we interpolate the boundary
 conditions from the parent grid (either the root grid or some other
 subgrid). The Poisson equation is then solved on every timestep using
 a multigrid technique on one subgrid at a time. Aside from

--- a/doc/manual/source/physics/hydro_methods.rst
+++ b/doc/manual/source/physics/hydro_methods.rst
@@ -4,7 +4,10 @@ Hydro and MHD Methods
 =====================
 
 There are four available methods in Enzo for calculating the evolution
-of the gas with and without magnetic fields. Below is a brief
+of the gas with and without magnetic fields.  **At present, Enzo's
+fluid methods only
+support gamma-law equations of state with constant adiabatic
+indices.**  Below is a brief
 description of each method, including the parameters associated with
 each one and a link to further reading. 
 For relevant parameters please also see :ref:`hydrodynamics_parameters`.

--- a/doc/manual/source/physics/index.rst
+++ b/doc/manual/source/physics/index.rst
@@ -22,5 +22,6 @@ Enzo parameters associated with them.
    shock_finding.rst
    cosmic_rays.rst
    additional_physics.rst
+   adaptive_mesh.rst
    analysis_modules.rst
 

--- a/doc/manual/source/reference/EnzoPrimaryReferences.rst
+++ b/doc/manual/source/reference/EnzoPrimaryReferences.rst
@@ -3,11 +3,13 @@
 Enzo Primary References
 =======================
 
-The Enzo method paper is not yet complete. However, there are several papers
-that describe the numerical methods used in Enzo, and this documentation
-contains a brief outline of the essential physics in Enzo, in
-:ref:`EnzoAlgorithms`.  These papers should be considered suitable for
-citations for Enzo in general:
+The Enzo method paper is `ENZO: An Adaptive Mesh Refinement Code for Astrophysics <https://ui.adsabs.harvard.edu/abs/2014ApJS..211...19B/abstract>`__
+by **Bryan et al.**, in The Astrophysical Journal.  This reference
+describes the essential physics and numerical methods in the Enzo code, which are also
+briefly outlined in :ref:`EnzoAlgorithms`.  In addition to the method paper, here are some
+older papers that also discuss earlier versions of the Enzo code
+or some subset of its algorithms:
+
 
 *  `Simulating X-Ray Clusters with Adaptive Mesh Refinement <http://adsabs.harvard.edu/abs/1997ASPC..123..363B>`__
    by **Bryan and Norman.** In "Computational Astrophysics; 12th

--- a/doc/manual/source/user_guide/index.rst
+++ b/doc/manual/source/user_guide/index.rst
@@ -17,12 +17,13 @@ The instructions on
 actually running the code are not comprehensive in that they are not
 machine or platform-specific.  Arguably the most useful and important
 piece of this guide is :ref:`parameters`, which contains
-descriptions of all of the roughly 300 possible input parameters (as
-of September 2008). For more detailed information on the Enzo
+descriptions of all of the roughly 650 possible input parameters (as
+of September 2019). For more detailed information on the Enzo
 algorithms and on running Enzo on different platforms, you should
 refer to the :doc:`building_enzo`. Detailed information on the
-algorithms used in Enzo will be available in the method paper
-(unreleased as of September 2008). In the meantime, see the
+algorithms used in Enzo are available in the method paper,
+`Bryan et al. 2014 <https://ui.adsabs.harvard.edu/abs/2014ApJS..211...19B/abstract>`_.
+In addition, see
 :ref:`EnzoPrimaryReferences` for more concrete Enzo information.
 
 This guide (and Enzo itself) was originally written by Greg


### PR DESCRIPTION
This PR addresses issues #95, #100, and #107 , as pointed out by @zingale.  Specifically, it:

- Updates sections of the user guide introduction to reflect the 2014 Enzo method paper and number of Enzo parameters (Issue #95 )
- Adds a new section to the documentation to describe the AMR algorithm in more detail (Issue #100)
- Clarifies capabilities/limitations in the fluid solvers and gravity solver (Issue #107 )