### PR TITLE
Star Particle Communication Bugfixes

### DIFF
--- a/src/enzo/CommunicationCollectParticles.C
+++ b/src/enzo/CommunicationCollectParticles.C
@@ -109,7 +109,8 @@ int CommunicationCollectParticles(LevelHierarchyEntry *LevelArray[],
   ActiveParticleList<ActiveParticleType> APSendList;
   ActiveParticleList<ActiveParticleType> APSharedList;
 
-  int NumberOfReceives, APNumberOfReceives, StarNumberOfReceives, TotalNumber, APTotalNumber;
+  int NumberOfReceives, APNumberOfReceives, StarNumberOfReceives,
+      TotalNumber, TotalStars, APTotalNumber;
   int *NumberToMove = new int[NumberOfProcessors];
   int *StarsToMove = new int[NumberOfProcessors];
   int *APNumberToMove = new int[NumberOfProcessors];
@@ -194,7 +195,7 @@ int CommunicationCollectParticles(LevelHierarchyEntry *LevelArray[],
         if (MoveStars)
           GridHierarchyPointer[j]->GridData->TransferSubgridStars
             (SubgridPointers, NumberOfSubgrids, StarsToMove, Zero, Zero, 
-             StarSendList, KeepLocal, ParticlesAreLocal, COPY_OUT);
+             StarSendList, KeepLocal, ParticlesAreLocal, COPY_OUT, FALSE, TRUE);
         
         GridHierarchyPointer[j]->GridData->TransferSubgridActiveParticles
           (SubgridPointers, NumberOfSubgrids, APNumberToMove, Zero, Zero,
@@ -213,13 +214,17 @@ int CommunicationCollectParticles(LevelHierarchyEntry *LevelArray[],
     /* Now allocate the memory once and store the particles to move */
 
     TotalNumber = 0;
+    TotalStars  = 0;
     for (j = 0; j < NumberOfProcessors; j++) {
       TotalNumber += NumberToMove[j];
+      TotalStars += StarsToMove[j];
       APTotalNumber += APNumberToMove[j];
       NumberToMove[j] = 0;  // Zero-out to use in the next step
+      StarsToMove[j]  = 0;  // Zero-out to use in the next step
       APNumberToMove[j] = 0;
     }
     SendList = new particle_data[TotalNumber];
+    StarSendList = new star_data[TotalStars];
 
     for (j = 0; j < NumberOfGrids; j++)
       if (GridHierarchyPointer[j]->NextGridNextLevel != NULL) {
@@ -228,6 +233,11 @@ int CommunicationCollectParticles(LevelHierarchyEntry *LevelArray[],
 	    GridHierarchyPointer[j]->GridData->ReturnNumberOfStars() == 0 &&
         GridHierarchyPointer[j]->GridData->ReturnNumberOfActiveParticles() == 0)
 	  continue;
+
+
+        GridHierarchyPointer[k]->GridData->TransferSubgridStars
+            (SubgridPointers, NumberOfSubgrids, StarsToMove, Zero, Zero,
+             StarSendList, KeepLocal, ParticlesAreLocal, COPY_OUT, FALSE, FALSE);
 
     GridHierarchyPointer[j]->GridData->TransferSubgridActiveParticles
         (SubgridPointers, NumberOfSubgrids, APNumberToMove, Zero, Zero,
@@ -531,9 +541,6 @@ int CommunicationCollectParticles(LevelHierarchyEntry *LevelArray[],
     for (j = StartGrid; j < EndGrid; j++)
       GridHierarchyPointer[j]->GridData->CollectActiveParticles
         (j, APNumberToMove, StartNum, Zero, APSendList, COPY_OUT);
-
-    if (StarsToMove[MyProcessorNumber] > 0)
-      printf("CCP: moving stars!\n");
 
     /* Share the particle move list */
 

--- a/src/enzo/CommunicationTransferSubgridParticles.C
+++ b/src/enzo/CommunicationTransferSubgridParticles.C
@@ -57,7 +57,7 @@ int CommunicationTransferSubgridParticles(LevelHierarchyEntry *LevelArray[],
 					  TopGridData *MetaData, int level)
 {
 
-  int proc, i, j, k, jstart, jend, TotalNumber, APTotalNumber;
+  int proc, i, j, k, jstart, jend, TotalNumber, TotalStars, APTotalNumber;
   int particle_data_size, star_data_size;
   int Zero = 0;
 
@@ -159,7 +159,7 @@ int CommunicationTransferSubgridParticles(LevelHierarchyEntry *LevelArray[],
 
     Grids[grid1]->GridData->TransferSubgridStars
       (GridPointers, NumberOfGrids, StarsToMove, Zero, Zero, 
-       StarSendList, KeepLocal, ParticlesAreLocal, COPY_OUT, TRUE);
+       StarSendList, KeepLocal, ParticlesAreLocal, COPY_OUT, TRUE, TRUE);
 
     Grids[grid1]->GridData->TransferSubgridActiveParticles
       (GridPointers, NumberOfGrids, APNumberToMove, Zero, Zero,
@@ -176,16 +176,24 @@ int CommunicationTransferSubgridParticles(LevelHierarchyEntry *LevelArray[],
   /* Allocate the memory for the move list and transfer the particles */
 
   TotalNumber = 0;
+  TotalStars  = 0;
   APTotalNumber = 0;
   for (j = 0; j < NumberOfProcessors; j++) {
     TotalNumber += NumberToMove[j];
+    TotalStars  += StarsToMove[j];
     APTotalNumber += APNumberToMove[j];
     NumberToMove[j] = 0;  // Zero-out to use in the next step
+    StarsToMove[j]  = 0;
     APNumberToMove[j] = 0;
   }
   SendList = new particle_data[TotalNumber];
+  StarSendList = new star_data[TotalStars];
 
   for (grid1 = 0; grid1 < NumberOfGrids; grid1++) {
+
+    Grids[grid1]->GridData->TransferSubgridStars
+      (GridPointers, NumberOfGrids, StarsToMove, Zero, Zero,
+       StarSendList, KeepLocal, ParticlesAreLocal, COPY_OUT, TRUE, FALSE);
 
     Grids[grid1]->GridData->TransferSubgridActiveParticles
       (GridPointers, NumberOfGrids, APNumberToMove, Zero, Zero,

--- a/src/enzo/Grid.h
+++ b/src/enzo/Grid.h
@@ -1727,7 +1727,8 @@ int CommunicationTransferActiveParticles(grid* Grids[], int NumberOfGrids,
 			   int EndIndex, star_data* &List, 
 			   bool KeepLocal, bool ParticlesAreLocal,
 			   int CopyDirection,
-			   int IncludeGhostZones = FALSE);
+			   int IncludeGhostZones = FALSE,
+                           int CountOnly = FALSE);
 
 int TransferSubgridActiveParticles(grid* Subgrids[], int NumberOfSubgrids,
                      int* &NumberToMove, int StartIndex,

--- a/src/enzo/Grid_CollectStars.C
+++ b/src/enzo/Grid_CollectStars.C
@@ -35,7 +35,6 @@ int grid::CollectStars(int GridNum, int* &NumberToMove,
 
   int i, j, dim, n1, grid, proc;
   Star *MoveStar;
-  StarBuffer *TempBuffer;
 
   /* ----------------------------------------------------------------- */
   /* Copy star out of grid. */
@@ -64,17 +63,15 @@ int grid::CollectStars(int GridNum, int* &NumberToMove,
       ENZO_FAIL("Star pointer cannot be NULL here.  NumberOfStars "
 		"and star pointer are mismatched.");
 
-    n1 = StartIndex;
-    TempBuffer = Stars->StarListToBuffer(NumberOfStars);
-    DeleteStarList(Stars);
-    
-    for (i = 0, n1 = StartIndex; i < NumberOfStars; i++, n1++) {
-      List[n1].data = TempBuffer[i];
+    for (i = 0, n1 = StartIndex, MoveStar = Stars; i < NumberOfStars;
+         i++, n1++, MoveStar = MoveStar->NextStar) {
+      MoveStar->StarToBuffer(&List[n1].data);
       List[n1].grid = GridNum;
       List[n1].proc = ProcessorNumber;
     } // ENDFOR stars
 
     StartIndex = n1;
+    DeleteStarList(Stars);
     NumberOfStars = 0;
 
   } // end: if (COPY_OUT)

--- a/src/enzo/Grid_CommunicationSendStars.C
+++ b/src/enzo/Grid_CommunicationSendStars.C
@@ -72,7 +72,7 @@ int grid::CommunicationSendStars(grid *ToGrid, int ToProcessor)
   /* If this is the from processor, pack fields and delete stars. */
 
   if (MyProcessorNumber == ProcessorNumber) {
-    buffer = this->Stars->StarListToBuffer(this->NumberOfStars);
+    this->Stars->StarListToBuffer(buffer, this->NumberOfStars);
     DeleteStarList(this->Stars);
   }
     

--- a/src/enzo/Grid_CommunicationTransferStarsOpt.C
+++ b/src/enzo/Grid_CommunicationTransferStarsOpt.C
@@ -135,17 +135,16 @@ int grid::CommunicationTransferStars(grid* Grids[], int NumberOfGrids,
 
     if (TotalToMove > PreviousTotalToMove) {
  
+      /* Move stars into list */
+
       // Increase the size of the list to include the stars from this grid
 
       star_data *NewList = new star_data[TotalToMove];
       memcpy(NewList, List, PreviousTotalToMove * sizeof(star_data));
       delete [] List;
       List = NewList;
- 
-      /* Move stars into list */
 
       int n1 = PreviousTotalToMove;
-      StarBuffer *TempBuffer;
 
       cstar = Stars;
       Stars = NULL;
@@ -158,8 +157,7 @@ int grid::CommunicationTransferStars(grid* Grids[], int NumberOfGrids,
 	grid = ToGrid[i];
 
 	if (grid != ThisGridNum) {
-	  TempBuffer = MoveStar->StarListToBuffer(1);
-	  List[n1].data = *TempBuffer;
+          MoveStar->StarToBuffer(&List[n1].data);
 	  List[n1].grid = grid;
 	  List[n1].proc = MyProcessorNumber;
 	  n1++;

--- a/src/enzo/Grid_TransferSubgridStars.C
+++ b/src/enzo/Grid_TransferSubgridStars.C
@@ -34,7 +34,8 @@ int grid::TransferSubgridStars(grid* Subgrids[], int NumberOfSubgrids,
 			       int* &NumberToMove, int StartIndex, 
 			       int EndIndex, star_data* &List, 
 			       bool KeepLocal, bool ParticlesAreLocal,
-			       int CopyDirection, int IncludeGhostZones)
+			       int CopyDirection, int IncludeGhostZones,
+                               int CountOnly)
 {
  
   /* Declarations. */
@@ -42,7 +43,6 @@ int grid::TransferSubgridStars(grid* Subgrids[], int NumberOfSubgrids,
   int i, j, index, dim, n1, grid, proc;
   int i0, j0, k0;
   Star *cstar, *MoveStar;
-  StarBuffer *TempBuffer;
 
   /* ----------------------------------------------------------------- */
   /* Copy stars out of grid. */
@@ -120,6 +120,11 @@ int grid::TransferSubgridStars(grid* Subgrids[], int NumberOfSubgrids,
       
     } // ENDFOR stars
 
+    if (CountOnly == TRUE) {
+      delete [] subgrid;
+      return SUCCESS;
+    }
+
     /* Allocate space. */
  
     int TotalToMove = 0;
@@ -127,14 +132,6 @@ int grid::TransferSubgridStars(grid* Subgrids[], int NumberOfSubgrids,
       TotalToMove += NumberToMove[proc];
  
     if (TotalToMove > PreviousTotalToMove) {
-
-      // Increase the size of the list to include the stars from
-      // this grid
-
-      star_data *NewList = new star_data[TotalToMove];
-      memcpy(NewList, List, PreviousTotalToMove * sizeof(star_data));
-      delete [] List;
-      List = NewList;
 
       /* Move stars */
 
@@ -148,10 +145,9 @@ int grid::TransferSubgridStars(grid* Subgrids[], int NumberOfSubgrids,
 	MoveStar = PopStar(cstar); // also advances to NextStar
 
 	if (subgrid[i] >= 0) {
-	  TempBuffer = MoveStar->StarListToBuffer(1);
+          MoveStar->StarToBuffer(&List[n1].data);
 	  delete MoveStar;
 
-	  List[n1].data = *TempBuffer;
 	  List[n1].grid = subgrid[i];
 	  List[n1].proc = (KeepLocal) ? MyProcessorNumber :
 	    Subgrids[subgrid[i]]->ReturnProcessorNumber();

--- a/src/enzo/Star.h
+++ b/src/enzo/Star.h
@@ -174,7 +174,8 @@ public:
 #endif
 
   Star* StarBufferToList(StarBuffer *buffer, int n);
-  StarBuffer* StarListToBuffer(int n);
+  void StarListToBuffer(StarBuffer *&result, int n);
+  void StarToBuffer(StarBuffer *result);
   
 };
 

--- a/src/enzo/StarParticleFindAll.C
+++ b/src/enzo/StarParticleFindAll.C
@@ -17,6 +17,7 @@
 #endif /* USE_MPI */
 #include <stdlib.h>
 #include <stdio.h>
+#include <math.h>
 #include "ErrorExceptions.h"
 #include "macros_and_parameters.h"
 #include "typedefs.h"
@@ -34,6 +35,12 @@
 static int FirstTimeCalled = TRUE;
 static MPI_Datatype MPI_STAR;
 #endif
+
+/* Global communication buffers to avoid reallocations and 
+   this memory fragmentation */
+
+StarBuffer *recvBuffer = NULL, *sendBuffer = NULL;
+int recvBufferSize = 0, sendBufferSize = 0;
 
 void InsertStarAfter(Star * &Node, Star * &NewNode);
 void DeleteStarList(Star * &Node);
@@ -121,7 +128,6 @@ int StarParticleFindAll(LevelHierarchyEntry *LevelArray[], Star *&AllStars)
 
     Eint32 *nCount = new Eint32[NumberOfProcessors];
     Eint32 *displace = new Eint32[NumberOfProcessors];
-    StarBuffer *recvBuffer, *sendBuffer;
 
     MPI_Allgather(&LocalNumberOfStars, 1, MPI_INT, nCount, 1, MPI_INT, 
 		  MPI_COMM_WORLD);
@@ -137,8 +143,17 @@ int StarParticleFindAll(LevelHierarchyEntry *LevelArray[], Star *&AllStars)
 
     if (TotalNumberOfStars > 0) {
 
-      recvBuffer = new StarBuffer[TotalNumberOfStars];
-      sendBuffer = LocalStars->StarListToBuffer(LocalNumberOfStars);
+      if (TotalNumberOfStars > recvBufferSize) {
+        recvBufferSize = ceil_log2(TotalNumberOfStars);
+        delete [] recvBuffer;
+        recvBuffer = new StarBuffer[recvBufferSize];
+      }
+      if (LocalNumberOfStars > sendBufferSize) {
+        sendBufferSize = ceil_log2(LocalNumberOfStars);
+        delete [] sendBuffer;
+        sendBuffer = new StarBuffer[sendBufferSize];
+      }
+      LocalStars->StarListToBuffer(sendBuffer, LocalNumberOfStars);
 
       /* Share all data with all processors */
 
@@ -170,8 +185,7 @@ int StarParticleFindAll(LevelHierarchyEntry *LevelArray[], Star *&AllStars)
 
       } // ENDFOR stars
 
-      delete [] recvBuffer;
-      delete [] sendBuffer;
+      DeleteStarList(LocalStars);
 
     } /* ENDIF TotalNumberOfStars > 0 */
 

--- a/src/enzo/StarRoutines.C
+++ b/src/enzo/StarRoutines.C
@@ -528,10 +528,9 @@ RadiationSourceEntry* Star::RadiationSourceInitialize(void)
      CONVERSION ROUTINES FROM/TO ARRAY BUFFERS
 **************************************************/
 
-StarBuffer* Star::StarListToBuffer(int n)
+void Star::StarListToBuffer(StarBuffer *&result, int n)
 {
   int i, count = 0;
-  StarBuffer *result = new StarBuffer[n];
   Star *tmp = this;
   while (tmp != NULL) {
     for (i = 0; i < MAX_DIMENSION; i++) {
@@ -567,5 +566,43 @@ StarBuffer* Star::StarListToBuffer(int n)
     count++;
     tmp = tmp->NextStar;
   }
-  return result;
+  return;
 }
+
+void Star::StarToBuffer(StarBuffer *result)
+{
+  int i, count = 0;
+  Star *tmp = this;
+  for (i = 0; i < MAX_DIMENSION; i++) {
+    result->pos[i] = tmp->pos[i];
+    result->vel[i] = tmp->vel[i];
+    result->delta_vel[i] = tmp->delta_vel[i];
+    result->accreted_angmom[i] = tmp->accreted_angmom[i];
+  }
+  result->naccretions = tmp->naccretions;
+  for (i = 0; i < tmp->naccretions; i++) {
+    result->accretion_rate[i] = tmp->accretion_rate[i];
+    result->accretion_time[i] = tmp->accretion_time[i];
+  }
+  for (i = tmp->naccretions; i < MAX_ACCR; i++) {
+    result->accretion_rate[i] = 0.0;
+    result->accretion_time[i] = 0.0;
+  }
+  result->Mass = tmp->Mass;
+  result->FinalMass = tmp->FinalMass;
+  result->DeltaMass = tmp->DeltaMass;
+  result->BirthTime = tmp->BirthTime;
+  result->LifeTime = tmp->LifeTime;
+  result->Metallicity = tmp->Metallicity;
+  result->deltaZ = tmp->deltaZ;
+  result->last_accretion_rate = tmp->last_accretion_rate;    
+  result->NotEjectedMass = tmp->NotEjectedMass;    
+  result->FeedbackFlag = tmp->FeedbackFlag;
+  result->Identifier = tmp->Identifier;
+  result->level = tmp->level;
+  result->GridID = tmp->GridID;
+  result->type = tmp->type;
+  result->AddedEmissivity = tmp->AddedEmissivity;
+  return;
+}
+

--- a/src/enzo/macros_and_parameters.h
+++ b/src/enzo/macros_and_parameters.h
@@ -369,6 +369,8 @@ typedef long long int   HDF5_hid_t;
 #define POW(X,Y) pow((double) (X), (double) (Y))
 #define COS(X) cos((double) (X))
 #define SIN(X) sin((double) (X))
+#define ceil_log2(size) ((size) > 1 ? ((size_t)pow(2, (int)log2(size-1)+1)) : 1 )
+
 #ifdef CONFIG_PFLOAT_4
 #define MODF(X,Y) modff((X), (Y))
 #elif CONFIG_PFLOAT_8

--- a/src/enzo/pop3_maker.F
+++ b/src/enzo/pop3_maker.F
@@ -172,7 +172,7 @@ c
                bmass = d(i,j,k) * m1
 c               isosndsp2 = sndspdC * temp(i,j,k)
 c               jeanmass = pi_val/(6._RKIND*sqrt(d(i,j,k)*dble(d1))) *
-c     &                    dble(pi_val * isosndsp2 / GravConst**1.5_RKIND / SolarMass
+c     &                    dble(pi_val * isosndsp2 / GravConst)**1.5_RKIND / SolarMass
 c
 c               if (bmass .lt. jeanmass) 
 c     &            write(40,*) '2',bmass,jeanmass

--- a/src/enzo/typedefs.h
+++ b/src/enzo/typedefs.h
@@ -192,8 +192,8 @@ enum field_type {Density, TotalEnergy, InternalEnergy, Pressure,
                  FieldUndefined};
 */
 
-#define FieldTypeIsDensity(A) ((((A) >= TotalEnergy && (A) <= Velocity3) || ((A) >= kphHI && (A) <= kdissH2I) || ((A) >= RadiationFreq0 && (A) <= RaySegments) || ((A) >= Bfield1 && (A) <= AccelerationField3)) ? FALSE : TRUE)
-#define FieldTypeIsRadiation(A) ((((A) >= kphHI && (A) <= kdissH2I) || ((A) >= RadiationFreq0 && (A) <= RadiationFreq9)) ? TRUE : FALSE)
+#define FieldTypeIsDensity(A) ((((A) >= TotalEnergy && (A) <= Velocity3) || ((A) >= kphHI && (A) <= kdissH2I) || ((A) == kdissH2II) || ((A) == kphHM) || ((A) >= RadiationFreq0 && (A) <= RaySegments) || ((A) >= Bfield1 && (A) <= AccelerationField3)) ? FALSE : TRUE)
+#define FieldTypeIsRadiation(A) ((((A) >= kphHI && (A) <= kdissH2I) || ((A) == kdissH2II) || ((A) == kphHM) || ((A) >= RadiationFreq0 && (A) <= RadiationFreq9)) ? TRUE : FALSE)
 #define FieldTypeNoInterpolate(A) (((((A) >= Mach) && ((A) <= PreShockDensity)) || ((A) == GravPotential) || ((A) == RaySegments)) ? TRUE : FALSE)
 
 /* Different stochastic forcing types */


### PR DESCRIPTION
This fixes / improves star particle communication to address memory fragmentation and performance issues when running with many (> 10k) star particle objects.

These changes are all circa 2016, but fell through the cracks in getting pulled into the main repository. Caught this when merging my fork with the active particle changes. Some of these changes parallel what is done with active particles. 

All credit goes to John Wise, stemming from the following commits: [May 2016 (1 of 2)](https://bitbucket.org/jwise77/enzo-dev/commits/ba5202af3d2c6102bd82ca644fed3c373e6552e8), [May 2016 (2 of 2)](https://bitbucket.org/jwise77/enzo-dev/commits/703f1091d58a4e12cc6720bc08ef12581e56792f), [June, 2016](https://bitbucket.org/jwise77/enzo-dev/commits/2981eb07b9effb06e490a38047fefa5bfb8237a2)