### PR TITLE
Optically Thin Source Clustering

### DIFF
--- a/doc/manual/source/parameters/index.rst
+++ b/doc/manual/source/parameters/index.rst
@@ -2729,7 +2729,7 @@ Radiative Transfer (Ray Tracing) Parameters
     which is the luminosity weighted center of two sources. This radius
     is in units of the separation of two sources associated with one
     SuperSource. If set too small, there will be angular artifacts in
-    the radiation field. Default: 10.0
+    the radiation field. Default: 3.0
 ``RadiativeTransferSourceBeamAngle`` (external)
     Rays will be emitted within this angle in degrees of the poles from sources with "Beamed" types.  Default: 30
 ``RadiativeTransferPeriodicBoundary`` (external)

--- a/doc/manual/source/parameters/index.rst
+++ b/doc/manual/source/parameters/index.rst
@@ -2714,12 +2714,22 @@ Radiative Transfer (Ray Tracing) Parameters
 ``RadiativeTransferSourceClustering`` (external)
     Set to 1 to turn on ray merging from combined virtual sources on a
     binary tree. Default: 0.
+``RadiativeTransferOpticallyThinSourceClustering`` (external)
+    Set to 1 to use the above tree when computing optically thin radiation
+    (``RadiativeTransferSourceClustering`` must be set to 1), which can greatly
+    reduce computational time for many sources / large cell counts. If on, this
+    source clustering is only used when the number of sources is greater than
+    ten. Testing in idealized galaxy simulations has shown that this
+    should be used with some caution. Its behavior is sensitive to
+    the value of ``RadiativeTransferPhotonMergeRadius``. Larger values tend
+    to significantly underestimate radiation near individual sources; it
+    is recommended to first try and use values around 3. Default: 0
 ``RadiativeTransferPhotonMergeRadius`` (external)
     The radius at which the rays will merge from their SuperSource,
     which is the luminosity weighted center of two sources. This radius
     is in units of the separation of two sources associated with one
     SuperSource. If set too small, there will be angular artifacts in
-    the radiation field. Default: 2.5
+    the radiation field. Default: 10.0
 ``RadiativeTransferSourceBeamAngle`` (external)
     Rays will be emitted within this angle in degrees of the poles from sources with "Beamed" types.  Default: 30
 ``RadiativeTransferPeriodicBoundary`` (external)

--- a/src/enzo/Grid_AddH2Dissociation.C
+++ b/src/enzo/Grid_AddH2Dissociation.C
@@ -32,11 +32,9 @@ int grid::AddH2Dissociation(Star *AllStars, int NumberOfSources)
      have more than 10 sources.  With smaller numbers, the overhead
      makes the direct calculation faster. */
 
-#ifdef LWTREE
-  if (RadiativeTransferSourceClustering == TRUE && NumberOfSources >= 10)
+  if (RadiativeTransferOpticallyThinSourceClustering == TRUE && NumberOfSources >= 10)
     this->AddH2DissociationFromTree();
   else
-#endif
     this->AddH2DissociationFromSources(AllStars);
 
   return SUCCESS;

--- a/src/enzo/RadiativeTransferParameters.h
+++ b/src/enzo/RadiativeTransferParameters.h
@@ -52,6 +52,13 @@ EXTERN int RadiativeTransferTimestepVelocityLevel;
 
 EXTERN int RadiativeTransferSourceClustering;
 
+/* If source clustering is turned on (above) this uses the same clustering
+   algorithm for optically thin radiation (if present). By default, this
+   is only used if on and greater than 10 sources are present. Otherwise,
+   reverts to the default source-by-source / cell-by-cell 1/r^2 method */
+
+EXTERN int RadiativeTransferOpticallyThinSourceClustering;
+
 /* Radius to merge rays in units of separation of the two sources
    associated with a super source. */
 

--- a/src/enzo/RadiativeTransferReadParameters.C
+++ b/src/enzo/RadiativeTransferReadParameters.C
@@ -62,6 +62,7 @@ int RadiativeTransferReadParameters(FILE *fptr)
   RadiativeTransferPhotonEscapeRadius         = 0.0;   // kpc
   RadiativeTransferInterpolateField           = FALSE;
   RadiativeTransferSourceClustering           = FALSE;
+  RadiativeTransferOpticallyThinSourceClustering = FALSE;
   RadiativeTransferPhotonMergeRadius          = 10.0;
   RadiativeTransferTimestepVelocityLimit      = 100.0; // km/s
   RadiativeTransferTimestepVelocityLevel      = INT_UNDEFINED;
@@ -127,6 +128,8 @@ int RadiativeTransferReadParameters(FILE *fptr)
 		  &RadiativeTransferInterpolateField);
     ret += sscanf(line, "RadiativeTransferSourceClustering = %"ISYM, 
 		  &RadiativeTransferSourceClustering);
+    ret += sscanf(line, "RadiativeTransferOpticallyThinSourceClustering = %"ISYM,
+                  &RadiativeTransferOpticallyThinSourceClustering);
     ret += sscanf(line, "RadiativeTransferPhotonMergeRadius = %"FSYM, 
 		  &RadiativeTransferPhotonMergeRadius);
     ret += sscanf(line, "RadiativeTransferFLDCallOnLevel = %"ISYM, 
@@ -229,7 +232,19 @@ int RadiativeTransferReadParameters(FILE *fptr)
 
   // If RadiativeTransferFLD > 1, ensure that ImplicitProblem > 0
   if (RadiativeTransferFLD > 1  &&  (ImplicitProblem == 0)) 
-    ENZO_FAIL("Error: RadiativeTransferFLD > 1 requires ImplicitProblem > 0!")
+    ENZO_FAIL("Error: RadiativeTransferFLD > 1 requires ImplicitProblem > 0!");
+
+  // Make sure source clustering is turned on if optically thin source clustering
+  // is to be used. Throw an error just in case.
+  if (!RadiativeTransferSourceClustering && RadiativeTransferOpticallyThinSourceClustering)
+    ENZO_FAIL("Error: RadiativeTransferSourceClustering must be turned on to use optically thin source clustering");
+
+  if (RadiativeTransferOpticallyThinSourceClustering &&
+      (RadiativeTransferPhotonMergeRadius > 5.0)){
+    fprintf(stderr, "Warning: Caution when using optically thin source clustering and "
+                    "values for RadiativeTransferPhotonMergeRadius > 5. This may result in missing "
+                    "radiation near sources.\n");
+  }
 
 #ifdef USE_GRACKLE
   // Set some radiative transfer grackle parameters.

--- a/src/enzo/RadiativeTransferReadParameters.C
+++ b/src/enzo/RadiativeTransferReadParameters.C
@@ -63,7 +63,7 @@ int RadiativeTransferReadParameters(FILE *fptr)
   RadiativeTransferInterpolateField           = FALSE;
   RadiativeTransferSourceClustering           = FALSE;
   RadiativeTransferOpticallyThinSourceClustering = FALSE;
-  RadiativeTransferPhotonMergeRadius          = 10.0;
+  RadiativeTransferPhotonMergeRadius          = 3.0;
   RadiativeTransferTimestepVelocityLimit      = 100.0; // km/s
   RadiativeTransferTimestepVelocityLevel      = INT_UNDEFINED;
   RadiativeTransferPeriodicBoundary           = FALSE;


### PR DESCRIPTION
Removing an ifdef in favor of a run-time parameter to turn on / off source clustering with optically thin radiation. 

A few years ago I had tested this routine and found it to give strange results, but I recently tried to use this again and it looks like it is behaving well. I'm not sure what has changed between then and now that fixed this, but none of the commit logs in the clustering routines seem to be more recent than when I first looked at this. Its possible there was some issue in an unrelated piece of code from my individual stars methods that affected this that has since been fixed, but tracking this down would be hard. 

I added a word of caution to the docs on using this piece of code just in case weird things happen again. It speeds up computation considerably (> factor of 10) when using optically thin radiation (1/r^2 profiles) with many sources / grid cells.

My test simulation was a restart of one of my isolated dwarf galaxy runs with individual stars. At this particular point there were ~160 radiation sources. I'm attaching slices comparing the H2I disassociation rate computed using the default cell-by-cell / star-by-star 1/r^2 deposition and the source clustering algorithm, along with a radial profile comparison between the two. There are clearly errors very close to individual sources, but these are not large (**Edit:** I was somewhat wrong about how large they are, see added plots in comments).

Cell-by-cell (more expensive / accurate).... black points are sources
![cell-by-cell](https://user-images.githubusercontent.com/6494319/68442013-ac861280-0184-11ea-9eb9-95c223cca61f.png)

Optically thin source clustering with `RadiativeTransferPhotonMergeRadius=3`
![source-clustering](https://user-images.githubusercontent.com/6494319/68442023-b1e35d00-0184-11ea-8e89-27bf46e37619.png)

![radial_profile](https://user-images.githubusercontent.com/6494319/68442229-3e8e1b00-0185-11ea-897c-ed29fc6c590e.png)

I did find that the behavior is very sensitive to the value of `RadiativeTransferPhotonMergeRadius`. Smaller values (<5) seem to do well with not much error, but larger values (e.g. 10) smooth out the radiation near sources considerably. I added a note of caution about this.

I also changed the docs to reflect that the default value of `RadiativeTransferPhotonMergeRadius` is actually 10. And because I made an oopsie, there are two very minor commits in this PR that are also in PR#120 