### PR TITLE
Bugfix: NumberOfOutputsBeforeExit for sub-cycle outputs

### DIFF
--- a/src/enzo/OutputFromEvolveLevel.C
+++ b/src/enzo/OutputFromEvolveLevel.C
@@ -323,6 +323,18 @@ int OutputFromEvolveLevel(LevelHierarchyEntry *LevelArray[],TopGridData *MetaDat
 //       ENZO_FAIL("Error in WriteAllData.\n");
 //     }
 // #endif
+
+    if (MetaData->NumberOfOutputsBeforeExit){
+      MetaData->OutputsLeftBeforeExit--;
+      if (MetaData->OutputsLeftBeforeExit <= 0){
+        if (MyProcessorNumber == ROOT_PROCESSOR) {
+          fprintf(stderr, "Exiting after writing%"ISYM" datadumps.\n",
+                  MetaData->NumberOfOutputsBeforeExit);
+        }
+        ExitEnzo = TRUE;
+      }
+    }
+
   }//WriteOutput == TRUE
 
   if( ExitEnzo == TRUE ){


### PR DESCRIPTION
Simple PR. Not sure if this is a bugfix or if this check was intentionally left out of `OutputFromEvolveLevel`, but I feel including this check here makes sense (as I found out the hard way when I filled up my hard drive....).