### PR TITLE
Bugfix running with Grackle compiled but Grackle off

### DIFF
--- a/src/enzo/GrackleReadParameters.C
+++ b/src/enzo/GrackleReadParameters.C
@@ -1,0 +1,215 @@
+/***********************************************************************
+/
+/  READS GRACKLE PARAMETERS FROM INPUT FILE
+/
+/  written by: Andrew Emerick
+/  date:       December, 2019
+/  modified1:
+/
+/  PURPOSE:
+/
+/  NOTE: Handles reading of Grackle-specific parametrs and mapping
+/        shared parameters between Enzo and Grackle. Any new Grackle parameters
+/        should be read in here.
+/
+************************************************************************/
+
+#include "preincludes.h"
+#include <string.h>
+#include <stdio.h>
+#include <math.h>
+#include "ErrorExceptions.h"
+#include "macros_and_parameters.h"
+#include "typedefs.h"
+#include "global_data.h"
+#include "CosmologyParameters.h"
+
+
+int GetUnits(float *DensityUnits, float *LengthUnits,
+	     float *TemperatureUnits, float *TimeUnits,
+	     float *VelocityUnits, double *MassUnits, FLOAT Time);
+int CosmologyComputeExpansionFactor(FLOAT time, FLOAT *a, FLOAT *dadt);
+
+int GrackleReadParameters(FILE *fptr, FLOAT InitTime)
+{
+
+  char line[MAX_LINE_LENGTH];
+
+  /* First, check if Grackle is actually being used in this problem */
+  rewind(fptr);
+  while (fgets(line, MAX_LINE_LENGTH, fptr) != NULL) {
+    int ret = 0;
+    ret += sscanf(line, "use_grackle = %"ISYM, &use_grackle);
+  }
+
+#ifndef USE_GRACKLE
+  if (use_grackle == TRUE) {
+    ENZO_FAIL("Error: Enzo must be compiled with 'make grackle-yes' to run with use_grackle = 1.\n");
+  }
+#else
+
+  // Construct the Grackle chemistry data structure
+  //
+  chemistry_data *my_chemistry;
+  my_chemistry = new chemistry_data;
+  if (set_default_chemistry_parameters(my_chemistry) == FAIL) {
+    ENZO_FAIL("Error in grackle: set_default_chemistry_parameters\n");
+  }
+
+  grackle_data->use_grackle = use_grackle;
+  
+  if (use_grackle == FALSE) {
+    return SUCCESS;
+  }
+
+  char *dummy = new char[MAX_LINE_LENGTH];
+  dummy[0] = 0;
+
+  /* If we are actually using Grackle, overwrite Enzo's default parameters with
+     the Grackle quivalents. This overrides what is set in SetDefaultGlobalValues */
+  if (use_grackle){
+    // Map Grackle defaults to corresponding Enzo parameters
+    Gamma                                 = (float) grackle_data->Gamma;
+    MultiSpecies                          = (int) grackle_data->primordial_chemistry;
+    MetalCooling                          = (int) grackle_data->metal_cooling;
+    H2FormationOnDust                     = (int) grackle_data->h2_on_dust;
+    CloudyCoolingData.CMBTemperatureFloor = (int) grackle_data->cmb_temperature_floor;
+    ThreeBodyRate                         = (int) grackle_data->three_body_rate;
+    CIECooling                            = (int) grackle_data->cie_cooling;
+    H2OpticalDepthApproximation           = (int) grackle_data->h2_optical_depth_approximation;
+    PhotoelectricHeating                  = max((int) grackle_data->photoelectric_heating, 0);  // Grackle default is < 0
+    PhotoelectricHeatingRate              = (float) grackle_data->photoelectric_heating_rate;
+    CoolData.NumberOfTemperatureBins      = (int) grackle_data->NumberOfTemperatureBins;
+    RateData.CaseBRecombination           = (int) grackle_data->CaseBRecombination;
+    CoolData.TemperatureStart             = (float) grackle_data->TemperatureStart;
+    CoolData.TemperatureEnd               = (float) grackle_data->TemperatureEnd;
+    RateData.NumberOfDustTemperatureBins  = (int) grackle_data->NumberOfDustTemperatureBins;
+    RateData.DustTemperatureStart         = (float) grackle_data->DustTemperatureStart;
+    RateData.DustTemperatureEnd           = (float) grackle_data->DustTemperatureEnd;
+    CoolData.HydrogenFractionByMass       = (float) grackle_data->HydrogenFractionByMass;
+    CoolData.DeuteriumToHydrogenRatio     = (float) grackle_data->DeuteriumToHydrogenRatio;
+    CoolData.SolarMetalFractionByMass     = (float) grackle_data->SolarMetalFractionByMass;
+  } // end use_grackle
+
+
+  // Now, go back through parameter file to check for Grackle-specific
+  // parameters that do not have Enzo equivalents
+  rewind(fptr);
+  while (fgets(line, MAX_LINE_LENGTH, fptr) != NULL) {
+
+    int ret = 0;
+    ret += sscanf(line, "with_radiative_cooling = %d",
+                  &grackle_data->with_radiative_cooling);
+    ret += sscanf(line, "use_volumetric_heating_rate = %d",
+                    &grackle_data->use_volumetric_heating_rate);
+    ret += sscanf(line, "use_specific_heating_rate = %d",
+                    &grackle_data->use_specific_heating_rate);
+    ret += sscanf(line, "self_shielding_method = %d",
+                    &grackle_data->self_shielding_method);
+    ret += sscanf(line, "H2_self_shielding = %d",
+                    &grackle_data->H2_self_shielding);
+
+    if (sscanf(line, "grackle_data_file = %s", dummy) == 1) {
+      grackle_data->grackle_data_file = dummy;
+      ret++;
+    }
+    ret += sscanf(line, "UVbackground = %d", &grackle_data->UVbackground);
+    ret += sscanf(line, "Compton_xray_heating = %d",
+                    &grackle_data->Compton_xray_heating);
+    ret += sscanf(line, "LWbackground_intensity = %lf",
+                  &grackle_data->LWbackground_intensity);
+    ret += sscanf(line, "LWbackground_sawtooth_suppression = %d",
+                  &grackle_data->LWbackground_sawtooth_suppression);
+
+    /* If the dummy char space was used, then make another. */
+    if (*dummy != 0) {
+      dummy = new char[MAX_LINE_LENGTH];
+      dummy[0] = 0;
+      ret++;
+    }
+
+  }
+  /* clean up */
+  delete [] dummy;
+  rewind(fptr);
+
+  // Finally, map all Enzo parameters to their Grackle equivalents. These
+  // are read in ReadParameterFile
+  //
+  //
+  // grackle_data->with_radiative_cooling already set
+  // grackle_data->grackle_data_file already set
+  // grackle_data->UVbackground already set
+  // grackle_data->Compton_xray_heating already set
+  // grackle_data->LWbackground_intensity already set
+  // grackle_data->LWbackground_sawtooth_suppression already set
+  grackle_data->use_grackle                    = (Eint32) use_grackle;
+  grackle_data->Gamma                          = (double) Gamma;
+  grackle_data->primordial_chemistry           = (Eint32) MultiSpecies;
+  grackle_data->metal_cooling                  = (Eint32) MetalCooling;
+  grackle_data->h2_on_dust                     = (Eint32) H2FormationOnDust;
+  grackle_data->cmb_temperature_floor          = (Eint32) CloudyCoolingData.CMBTemperatureFloor;
+  grackle_data->three_body_rate                = (Eint32) ThreeBodyRate;
+  grackle_data->cie_cooling                    = (Eint32) CIECooling;
+  grackle_data->h2_optical_depth_approximation = (Eint32) H2OpticalDepthApproximation;
+  grackle_data->photoelectric_heating          = (Eint32) PhotoelectricHeating;
+  grackle_data->photoelectric_heating_rate     = (double) PhotoelectricHeatingRate;
+  grackle_data->NumberOfTemperatureBins        = (Eint32) CoolData.NumberOfTemperatureBins;
+  grackle_data->CaseBRecombination             = (Eint32) RateData.CaseBRecombination;
+  grackle_data->TemperatureStart               = (double) CoolData.TemperatureStart;
+  grackle_data->TemperatureEnd                 = (double) CoolData.TemperatureEnd;
+  grackle_data->NumberOfDustTemperatureBins    = (Eint32) RateData.NumberOfDustTemperatureBins;
+  grackle_data->DustTemperatureStart           = (double) RateData.DustTemperatureStart;
+  grackle_data->DustTemperatureEnd             = (double) RateData.DustTemperatureEnd;
+  grackle_data->HydrogenFractionByMass         = (double) CoolData.HydrogenFractionByMass;
+  grackle_data->DeuteriumToHydrogenRatio       = (double) CoolData.DeuteriumToHydrogenRatio;
+  grackle_data->SolarMetalFractionByMass       = (double) CoolData.SolarMetalFractionByMass;
+  grackle_data->UVbackground_redshift_on       = (double) CoolData.RadiationRedshiftOn;
+  grackle_data->UVbackground_redshift_off      = (double) CoolData.RadiationRedshiftOff;
+  grackle_data->UVbackground_redshift_fullon   = (double) CoolData.RadiationRedshiftFullOn;
+  grackle_data->UVbackground_redshift_drop     = (double) CoolData.RadiationRedshiftDropOff;
+  grackle_data->use_radiative_transfer         = (Eint32) RadiativeTransfer;
+  // grackle_data->radiative_transfer_coupled_rate_solver set in RadiativeTransferReadParameters
+  // grackle_data->radiative_transfer_hydrogen_only set in RadiativeTransferReadParameters
+
+  // Initialize Grackle units structure.
+  FLOAT a_value, dadt;
+  a_value = 1.0;
+  code_units grackle_units;
+  grackle_units.a_units = 1.0;
+  float DensityUnits = 1.0, LengthUnits = 1.0, TemperatureUnits = 1.0,
+    TimeUnits = 1.0, VelocityUnits = 1.0, MassUnits = 1.0;
+  if (GetUnits(&DensityUnits, &LengthUnits, &TemperatureUnits,
+               &TimeUnits, &VelocityUnits, &MassUnits, InitTime) == FAIL) {
+    ENZO_FAIL("Error in GetUnits.\n");
+  }
+  if (ComovingCoordinates) {
+    if (CosmologyComputeExpansionFactor(InitTime, &a_value,
+                                        &dadt) == FAIL) {
+      ENZO_FAIL("Error in CosmologyComputeExpansionFactors.\n");
+    }
+    grackle_units.a_units            = (double) (1.0 / (1.0 + InitialRedshift));
+  }
+  grackle_units.comoving_coordinates = (Eint32) ComovingCoordinates;
+  grackle_units.density_units        = (double) DensityUnits;
+  grackle_units.length_units         = (double) LengthUnits;
+  grackle_units.time_units           = (double) TimeUnits;
+  grackle_units.velocity_units       = (double) VelocityUnits;
+  grackle_units.a_value              = (double) a_value;
+
+  // Initialize chemistry structure.
+  if (initialize_chemistry_data(&grackle_units) == FAIL) {
+    ENZO_FAIL("Error in Grackle initialize_chemistry_data.\n");
+  }
+
+  // Need to set these after initialize_chemistry_data since
+  // that function sets them automatically based on the tables.
+  if (FinalRedshift < grackle_data->UVbackground_redshift_off) {
+    grackle_data->UVbackground_redshift_off = FinalRedshift;
+    grackle_data->UVbackground_redshift_drop = FinalRedshift;
+  }
+
+#endif // end USE_GRACKLE
+
+  return SUCCESS;
+}

--- a/src/enzo/GrackleReadParameters.C
+++ b/src/enzo/GrackleReadParameters.C
@@ -30,8 +30,10 @@ int GetUnits(float *DensityUnits, float *LengthUnits,
 	     float *VelocityUnits, double *MassUnits, FLOAT Time);
 int CosmologyComputeExpansionFactor(FLOAT time, FLOAT *a, FLOAT *dadt);
 
-int GrackleReadParameters(FILE *fptr, FLOAT InitTime)
-{
+int GrackleSetDefaultParameters(FILE *fptr){
+
+  // Check if Grackle is being used. If so, copy over Grackle's
+  // default parameters to their Enzo equivalents
 
   char line[MAX_LINE_LENGTH];
 
@@ -57,13 +59,6 @@ int GrackleReadParameters(FILE *fptr, FLOAT InitTime)
   }
 
   grackle_data->use_grackle = use_grackle;
-  
-  if (use_grackle == FALSE) {
-    return SUCCESS;
-  }
-
-  char *dummy = new char[MAX_LINE_LENGTH];
-  dummy[0] = 0;
 
   /* If we are actually using Grackle, overwrite Enzo's default parameters with
      the Grackle quivalents. This overrides what is set in SetDefaultGlobalValues */
@@ -91,8 +86,29 @@ int GrackleReadParameters(FILE *fptr, FLOAT InitTime)
     CoolData.SolarMetalFractionByMass     = (float) grackle_data->SolarMetalFractionByMass;
   } // end use_grackle
 
+#endif // end USE_GRACKLE
 
-  // Now, go back through parameter file to check for Grackle-specific
+  return SUCCESS;
+}
+
+int GrackleReadParameters(FILE *fptr, FLOAT InitTime)
+{
+  /* Read Grackle specific parameters and copy over Enzo
+     parameters to their Grackle equivalents. Concludes by
+     setting up grackle_units */
+
+  if (use_grackle == FALSE) {
+    return SUCCESS;
+  }
+
+  char line[MAX_LINE_LENGTH];
+  char *dummy = new char[MAX_LINE_LENGTH];
+  dummy[0] = 0;
+
+
+#ifdef USE_GRACKLE
+
+  // Go back through parameter file to check for Grackle-specific
   // parameters that do not have Enzo equivalents
   rewind(fptr);
   while (fgets(line, MAX_LINE_LENGTH, fptr) != NULL) {
@@ -130,7 +146,6 @@ int GrackleReadParameters(FILE *fptr, FLOAT InitTime)
 
   }
   /* clean up */
-  delete [] dummy;
   rewind(fptr);
 
   // Finally, map all Enzo parameters to their Grackle equivalents. These
@@ -210,6 +225,8 @@ int GrackleReadParameters(FILE *fptr, FLOAT InitTime)
   }
 
 #endif // end USE_GRACKLE
+
+  delete [] dummy;
 
   return SUCCESS;
 }

--- a/src/enzo/Make.config.objects
+++ b/src/enzo/Make.config.objects
@@ -330,6 +330,7 @@ OBJS_CONFIG_LIB = \
 	gFLDSplit_SetupBoundary.o \
 	gFLDSplit_SetupSystem.o \
 	gFLDSplit_WriteParameters.o \
+        GrackleReadParameters.o \
 	GravityEquilibriumTestInitialize.o \
 	Grid_AccelerationBoundaryRoutines.o \
 	Grid_AccessBaryonFields.o \

--- a/src/enzo/ReadParameterFile.C
+++ b/src/enzo/ReadParameterFile.C
@@ -48,6 +48,7 @@ int ReadListOfFloats(FILE *fptr, int N, float floats[]);
 int ReadListOfInts(FILE *fptr, int N, int nums[]);
 int CosmologyReadParameters(FILE *fptr, FLOAT *StopTime, FLOAT *InitTime);
 int GrackleReadParameters(FILE *fptr, FLOAT InitTime);
+int GrackleSetDefaultParameters(FILE *fptr);
 int ReadUnits(FILE *fptr);
 int InitializeCosmicRayData();
 int InitializeRateData(FLOAT Time);
@@ -79,6 +80,15 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
   char **active_particle_types;
   active_particle_types = new char*[MAX_ACTIVE_PARTICLE_TYPES];
   int active_particles = 0;
+
+#ifdef USE_GRACKLE
+  /* Check if use_grackle is True and copy over default parameters to
+     their Enzo equivalents */
+  if (GrackleSetDefaultParameters(fptr) == FAIL){
+    ENZO_FAIL("Error in GrackleSetDefaultParameters.\n");
+  }
+  rewind(fptr);
+#endif // USE_GRACKLE
 
   /* read until out of lines */
 
@@ -1622,7 +1632,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
   // make sure that MHD is turned on if we're trying to use anisotropic conduction.
   // if not, alert user.
   if(AnisotropicConduction==TRUE && UseMHD==0){
-    ENZO_FAIL("AnisotropicConduction can only be used if MHD is turnedf on!\n");
+    ENZO_FAIL("AnisotropicConduction can only be used if MHD is turned on!\n");
   }
   if(AnisotropicConduction==TRUE && MetaData.TopGridRank < 2){
     ENZO_FAIL("AnisotropicConduction can only be used if TopGridRank is >= 2!\n");

--- a/src/enzo/ReadParameterFile.C
+++ b/src/enzo/ReadParameterFile.C
@@ -16,11 +16,11 @@
 /  RETURNS: SUCCESS or FAIL
 /
 ************************************************************************/
- 
+
 // This routine reads the parameter file in the argument and sets parameters
 //   based on it.
 
-#include "preincludes.h" 
+#include "preincludes.h"
 #include <stdlib.h>
 #include <unistd.h>
 #include <vector>
@@ -32,21 +32,22 @@
 #include "ExternalBoundary.h"
 #include "Grid.h"
 #include "TopGridData.h"
-#include "hydro_rk/EOS.h" 
+#include "hydro_rk/EOS.h"
 #include "CosmologyParameters.h"
 #include "phys_constants.h"
 #include "ActiveParticle.h"
 
 /* This variable is declared here and only used in Grid_ReadGrid. */
- 
+
 
 
 /* function prototypes */
 
-void my_exit(int status); 
+void my_exit(int status);
 int ReadListOfFloats(FILE *fptr, int N, float floats[]);
 int ReadListOfInts(FILE *fptr, int N, int nums[]);
 int CosmologyReadParameters(FILE *fptr, FLOAT *StopTime, FLOAT *InitTime);
+int GrackleReadParameters(FILE *fptr, FLOAT InitTime);
 int ReadUnits(FILE *fptr);
 int InitializeCosmicRayData();
 int InitializeRateData(FLOAT Time);
@@ -58,8 +59,8 @@ int GetUnits(float *DensityUnits, float *LengthUnits,
 	     float *VelocityUnits, double *MassUnits, FLOAT Time);
 int CosmologyComputeExpansionFactor(FLOAT time, FLOAT *a, FLOAT *dadt);
 int ReadEvolveRefineFile(void);
- 
-int CheckShearingBoundaryConsistency(TopGridData &MetaData); 
+
+int CheckShearingBoundaryConsistency(TopGridData &MetaData);
 void get_uuid(char *buffer);
 
 int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
@@ -67,7 +68,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
   /* declarations */
 
-  
+
   char line[MAX_LINE_LENGTH];
   int i, dim, ret, int_dummy;
   float TempFloat, float_dummy;
@@ -79,75 +80,28 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
   active_particle_types = new char*[MAX_ACTIVE_PARTICLE_TYPES];
   int active_particles = 0;
 
-
-#ifdef USE_GRACKLE
-
-  /* check if Grackle is used in this problem */
-  rewind(fptr);
-  while ((fgets(line, MAX_LINE_LENGTH, fptr) != NULL) 
-      && (comment_count < 2)) {
-
-    ret = 0;
-    ret += sscanf(line, "use_grackle = %"ISYM, &use_grackle);
-  }
-
-  // Grackle chemistry data structure.
-  chemistry_data *my_chemistry;
-  my_chemistry = new chemistry_data;
-  if (set_default_chemistry_parameters(my_chemistry) == FAIL) {
-    ENZO_FAIL("Error in grackle: set_default_chemistry_parameters\n");
-  }
-
-  if (use_grackle){
-
-    // Map Grackle defaults to corresponding Enzo parameters
-    Gamma                                 = (float) grackle_data->Gamma;
-    MultiSpecies                          = (int) grackle_data->primordial_chemistry;
-    MetalCooling                          = (int) grackle_data->metal_cooling;
-    H2FormationOnDust                     = (int) grackle_data->h2_on_dust;
-    CloudyCoolingData.CMBTemperatureFloor = (int) grackle_data->cmb_temperature_floor;
-    ThreeBodyRate                         = (int) grackle_data->three_body_rate;
-    CIECooling                            = (int) grackle_data->cie_cooling;
-    H2OpticalDepthApproximation           = (int) grackle_data->h2_optical_depth_approximation;
-    PhotoelectricHeating                  = max((int) grackle_data->photoelectric_heating, 0);  // Grackle default is < 0
-    PhotoelectricHeatingRate              = (float) grackle_data->photoelectric_heating_rate;
-    CoolData.NumberOfTemperatureBins      = (int) grackle_data->NumberOfTemperatureBins;
-    RateData.CaseBRecombination           = (int) grackle_data->CaseBRecombination;
-    CoolData.TemperatureStart             = (float) grackle_data->TemperatureStart;
-    CoolData.TemperatureEnd               = (float) grackle_data->TemperatureEnd;
-    RateData.NumberOfDustTemperatureBins  = (int) grackle_data->NumberOfDustTemperatureBins;
-    RateData.DustTemperatureStart         = (float) grackle_data->DustTemperatureStart;
-    RateData.DustTemperatureEnd           = (float) grackle_data->DustTemperatureEnd;
-    CoolData.HydrogenFractionByMass       = (float) grackle_data->HydrogenFractionByMass;
-    CoolData.DeuteriumToHydrogenRatio     = (float) grackle_data->DeuteriumToHydrogenRatio;
-    CoolData.SolarMetalFractionByMass     = (float) grackle_data->SolarMetalFractionByMass;
-
-  } // end use_grackle
-
-#endif
-
   /* read until out of lines */
 
   rewind(fptr);
-  while ((fgets(line, MAX_LINE_LENGTH, fptr) != NULL) 
+  while ((fgets(line, MAX_LINE_LENGTH, fptr) != NULL)
       && (comment_count < 2)) {
 
     ret = 0;
- 
+
     /* read MetaData parameters */
- 
+
     ret += sscanf(line, "InitialCycleNumber = %"ISYM, &MetaData.CycleNumber);
     ret += sscanf(line, "InitialTime        = %"PSYM, &MetaData.Time);
     ret += sscanf(line, "InitialCPUTime     = %lf", &MetaData.CPUTime);
     ret += sscanf(line, "Initialdt          = %"FSYM, Initialdt);
- 
+
     ret += sscanf(line, "CheckpointRestart = %"ISYM, &CheckpointRestart);
     ret += sscanf(line, "StopTime    = %"PSYM, &MetaData.StopTime);
     ret += sscanf(line, "StopCycle   = %"ISYM, &MetaData.StopCycle);
     ret += sscanf(line, "StopSteps   = %"ISYM, &MetaData.StopSteps);
     ret += sscanf(line, "StopCPUTime = %"FSYM, &MetaData.StopCPUTime);
     ret += sscanf(line, "ResubmitOn  = %"ISYM, &MetaData.ResubmitOn);
-    if (sscanf(line, "ResubmitCommand = %s", dummy) == 1) 
+    if (sscanf(line, "ResubmitCommand = %s", dummy) == 1)
       MetaData.ResubmitCommand = dummy;
 
     ret += sscanf(line, "MaximumTopGridTimeStep = %"FSYM,
@@ -162,7 +116,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "TimeLastHistoryDump = %"PSYM,
 		  &MetaData.TimeLastHistoryDump);
     ret += sscanf(line, "dtHistoryDump       = %"PSYM, &MetaData.dtHistoryDump);
- 
+
     ret += sscanf(line, "TracerParticleOn  = %"ISYM, &TracerParticleOn);
     ret += sscanf(line, "TracerParticleOutputVelocity  = %"ISYM, &TracerParticleOutputVelocity);
     ret += sscanf(line, "WriteGhostZones = %"ISYM, &WriteGhostZones);
@@ -175,15 +129,15 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
                   &MetaData.dtTracerParticleDump);
     ret += sscanf(line, "TimeLastInterpolatedDataDump    = %"PSYM,
 		  &MetaData.TimeLastInterpolatedDataDump);
-    ret += sscanf(line, "dtInterpolatedDataDump          = %"PSYM, 
+    ret += sscanf(line, "dtInterpolatedDataDump          = %"PSYM,
 		  &MetaData.dtInterpolatedDataDump);
- 
-    ret += sscanf(line, "NewMovieLeftEdge  = %"PSYM" %"PSYM" %"PSYM, 
+
+    ret += sscanf(line, "NewMovieLeftEdge  = %"PSYM" %"PSYM" %"PSYM,
 		  MetaData.NewMovieLeftEdge,
-		  MetaData.NewMovieLeftEdge+1, 
+		  MetaData.NewMovieLeftEdge+1,
 		  MetaData.NewMovieLeftEdge+2);
-    ret += sscanf(line, "NewMovieRightEdge = %"PSYM" %"PSYM" %"PSYM, 
-		  MetaData.NewMovieRightEdge, 
+    ret += sscanf(line, "NewMovieRightEdge = %"PSYM" %"PSYM" %"PSYM,
+		  MetaData.NewMovieRightEdge,
 		  MetaData.NewMovieRightEdge+1,
 		  MetaData.NewMovieRightEdge+2);
 
@@ -225,26 +179,26 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
            &EnrichedMetalFraction);
 
     /* Subcycle directed output */
-    ret += sscanf(line, "SubcycleSkipDataDump = %"ISYM, 
+    ret += sscanf(line, "SubcycleSkipDataDump = %"ISYM,
                   &MetaData.SubcycleSkipDataDump);
-    ret += sscanf(line, "SubcycleLastDataDump = %"ISYM, 
+    ret += sscanf(line, "SubcycleLastDataDump = %"ISYM,
                   &MetaData.SubcycleLastDataDump);
-    ret += sscanf(line, "SubcycleNumber = %"ISYM, 
+    ret += sscanf(line, "SubcycleNumber = %"ISYM,
                   &MetaData.SubcycleNumber);
 
     ret += sscanf(line,"FileDirectedOutput = %"ISYM,
 		  &FileDirectedOutput);
 
     ret += sscanf(line,"HierarchyFileInputFormat = %"ISYM,
-		  &HierarchyFileInputFormat);    
+		  &HierarchyFileInputFormat);
     ret += sscanf(line,"HierarchyFileOutputFormat = %"ISYM,
-		  &HierarchyFileOutputFormat);    
+		  &HierarchyFileOutputFormat);
 
     ret += sscanf(line, "RestartDumpNumber = %"ISYM, &MetaData.RestartDumpNumber);
     ret += sscanf(line, "DataDumpNumber    = %"ISYM, &MetaData.DataDumpNumber);
     ret += sscanf(line, "HistoryDumpNumber = %"ISYM, &MetaData.HistoryDumpNumber);
     ret += sscanf(line, "TracerParticleDumpNumber = %"ISYM, &MetaData.TracerParticleDumpNumber);
- 
+
     if (sscanf(line, "RestartDumpName      = %s", dummy) == 1)
       MetaData.RestartDumpName = dummy;
     if (sscanf(line, "DataDumpName         = %s", dummy) == 1)
@@ -255,7 +209,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
       MetaData.TracerParticleDumpName = dummy;
     if (sscanf(line, "RedshiftDumpName     = %s", dummy) == 1)
       MetaData.RedshiftDumpName = dummy;
- 
+
     if (sscanf(line, "RestartDumpDir      = %s", dummy) == 1)
       MetaData.RestartDumpDir = dummy;
     if (sscanf(line, "DataDumpDir         = %s", dummy) == 1)
@@ -266,12 +220,12 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
       MetaData.TracerParticleDumpDir = dummy;
     if (sscanf(line, "RedshiftDumpDir     = %s", dummy) == 1)
       MetaData.RedshiftDumpDir = dummy;
- 
+
     if (sscanf(line, "LocalDir            = %s", dummy) == 1)
       MetaData.LocalDir = dummy;
     if (sscanf(line, "GlobalDir           = %s", dummy) == 1)
       MetaData.GlobalDir = dummy;
- 
+
     if (sscanf(line, "CubeDump[%"ISYM"] = %s", &dim, dummy) == 2) {
       ret++; CubeDumps[dim] = dummy;
       if (dim >= MAX_CUBE_DUMPS) {
@@ -285,10 +239,10 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "LoadBalancingCycleSkip = %"ISYM, &LoadBalancingCycleSkip);
     ret += sscanf(line, "LoadBalancingMinLevel = %"ISYM, &LoadBalancingMinLevel);
     ret += sscanf(line, "LoadBalancingMaxLevel = %"ISYM, &LoadBalancingMaxLevel);
- 
-    ret += sscanf(line, "ConductionDynamicRebuildHierarchy = %"ISYM, 
+
+    ret += sscanf(line, "ConductionDynamicRebuildHierarchy = %"ISYM,
                   &ConductionDynamicRebuildHierarchy);
-    ret += sscanf(line, "ConductionDynamicRebuildMinLevel = %"ISYM, 
+    ret += sscanf(line, "ConductionDynamicRebuildMinLevel = %"ISYM,
                   &ConductionDynamicRebuildMinLevel);
     if (sscanf(line, "RebuildHierarchyCycleSkip[%"ISYM"] =", &int_dummy) == 1) {
       if (int_dummy > MAX_DEPTH_OF_HIERARCHY) {
@@ -314,16 +268,16 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     if (sscanf(line, "TimeActionParameter[%"ISYM"] = ", &dim) == 1)
       ret += sscanf(line, "TimeActionParameter[%"ISYM"] = %"FSYM, &dim,
 		    TimeActionParameter+dim);
- 
+
     ret += sscanf(line, "StaticHierarchy = %"ISYM, &MetaData.StaticHierarchy);
- 
+
     ret += sscanf(line, "TopGridRank       = %"ISYM, &MetaData.TopGridRank);
     ret += sscanf(line, "TopGridDimensions = %"ISYM" %"ISYM" %"ISYM, MetaData.TopGridDims,
 		  MetaData.TopGridDims+1, MetaData.TopGridDims+2);
- 
+
     ret += sscanf(line, "TopGridGravityBoundary = %"ISYM,
 		  &MetaData.GravityBoundary);
- 
+
 #ifdef TRANSFER
     if (sscanf(line, "RadHydroParamfile = %s", dummy) == 1)
       MetaData.RadHydroParameterFname = dummy;
@@ -331,7 +285,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "ImplicitProblem = %"ISYM, &ImplicitProblem);
     ret += sscanf(line, "RadiativeTransferFLD   = %"ISYM, &RadiativeTransferFLD);
 #ifdef EMISSIVITY
-    ret += sscanf(line, "StarMakerEmissivityField = %"ISYM, 
+    ret += sscanf(line, "StarMakerEmissivityField = %"ISYM,
 		  &StarMakerEmissivityField);
     ret += sscanf(line, "uv_param = %"FSYM, &uv_param);
 #endif
@@ -340,7 +294,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 		  &MetaData.ParticleBoundaryType);
     ret += sscanf(line, "NumberOfParticles      = %"PISYM,
 		  &MetaData.NumberOfParticles);
- 
+
     ret += sscanf(line, "CourantSafetyNumber    = %"FSYM,
 		  &MetaData.CourantSafetyNumber);
     ret += sscanf(line, "PPMFlatteningParameter = %"ISYM,
@@ -349,9 +303,9 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 		  &MetaData.PPMDiffusionParameter);
     ret += sscanf(line, "PPMSteepeningParameter = %"ISYM,
 		  &MetaData.PPMSteepeningParameter);
- 
+
     /* read global Parameters */
- 
+
     ret += sscanf(line, "ProblemType            = %"ISYM, &ProblemType);
 #ifdef NEW_PROBLEM_TYPES
     if (sscanf(line, "ProblemTypeName = %s", dummy) == 1) {
@@ -390,7 +344,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 		  &ConservativeInterpolation);
     ret += sscanf(line, "MinimumEfficiency      = %"FSYM, &MinimumEfficiency);
     ret += sscanf(line, "SubgridSizeAutoAdjust  = %"ISYM, &SubgridSizeAutoAdjust);
-    ret += sscanf(line, "OptimalSubgridsPerProcessor = %"ISYM, 
+    ret += sscanf(line, "OptimalSubgridsPerProcessor = %"ISYM,
 		  &OptimalSubgridsPerProcessor);
     ret += sscanf(line, "MinimumSubgridEdge     = %"ISYM, &MinimumSubgridEdge);
     ret += sscanf(line, "MaximumSubgridSize     = %"ISYM, &MaximumSubgridSize);
@@ -401,9 +355,9 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 		  &MustRefineRegionMinRefinementLevel);
     ret += sscanf(line, "MetallicityRefinementMinLevel = %"ISYM,
 		  &MetallicityRefinementMinLevel);
-    ret += sscanf(line, "MetallicityRefinementMinMetallicity = %"FSYM, 
+    ret += sscanf(line, "MetallicityRefinementMinMetallicity = %"FSYM,
 		  &MetallicityRefinementMinMetallicity);
-    ret += sscanf(line, "MetallicityRefinementMinDensity = %"FSYM, 
+    ret += sscanf(line, "MetallicityRefinementMinDensity = %"FSYM,
 		  &MetallicityRefinementMinDensity);
 
     ret += sscanf(line, "DomainLeftEdge        = %"PSYM" %"PSYM" %"PSYM, DomainLeftEdge,
@@ -425,14 +379,14 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "MustRefineRegionRightEdge  = %"PSYM" %"PSYM" %"PSYM,
 		  MustRefineRegionRightEdge, MustRefineRegionRightEdge+1,
 		  MustRefineRegionRightEdge+2);
-  
+
     /* Parameters for the MultiRefineRegion mechanics */
-    
+
     ret += sscanf(line, "MultiRefineRegionMaximumOuterLevel  = %"ISYM, &MultiRefineRegionMaximumOuterLevel);
     ret += sscanf(line, "MultiRefineRegionMinimumOuterLevel  = %"ISYM, &MultiRefineRegionMinimumOuterLevel);
-    if (sscanf(line, "MultiRefineRegionMaximumLevel[%"ISYM"] = %"ISYM, &dim, &int_dummy) == 2) 
+    if (sscanf(line, "MultiRefineRegionMaximumLevel[%"ISYM"] = %"ISYM, &dim, &int_dummy) == 2)
       {
-	if (dim > MAX_STATIC_REGIONS-1) 
+	if (dim > MAX_STATIC_REGIONS-1)
 	  ENZO_VFAIL("MultiRefineRegion number %"ISYM" (MAX_STATIC_REGIONS) > MAX allowed\n", dim);
 	ret++;
 	MultiRefineRegionMaximumLevel[dim] = int_dummy;
@@ -526,7 +480,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
       DataLabel[dim] = dummy;
     if (sscanf(line, "DataUnits[%"ISYM"] = %s\n", &dim, dummy) == 2)
       DataUnits[dim] = dummy;
- 
+
     ret += sscanf(line, "StoreDomainBoundaryMassFlux  = %"ISYM, &StoreDomainBoundaryMassFlux);
     if (sscanf(line, "BoundaryMassFluxFilename = %s", dummy) == 1) {
       BoundaryMassFluxFilename = dummy;
@@ -540,13 +494,13 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     if (sscanf(line, "BoundaryMassFluxContainer[%"ISYM"]        = %"FSYM, &dim, &float_dummy)){
        BoundaryMassFluxContainer[dim] = float_dummy; ret++;
     }
- 
+
     ret += sscanf(line, "UniformGravity          = %"ISYM, &UniformGravity);
     ret += sscanf(line, "UniformGravityDirection = %"ISYM,
 		  &UniformGravityDirection);
     ret += sscanf(line, "UniformGravityConstant  = %"FSYM,
 		  &UniformGravityConstant);
- 
+
     ret += sscanf(line, "PointSourceGravity         = %"ISYM,&PointSourceGravity);
     ret += sscanf(line, "PointSourceGravityPosition = %"PSYM" %"PSYM" %"PSYM,
 		  PointSourceGravityPosition, PointSourceGravityPosition+1,
@@ -555,7 +509,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 		  &PointSourceGravityConstant);
     ret += sscanf(line, "PointSourceGravityCoreRadius = %"FSYM,
 		  &PointSourceGravityCoreRadius);
- 
+
     ret += sscanf(line, "DiskGravity                        = %"ISYM,&DiskGravity);
     ret += sscanf(line, "DiskGravityPosition                = %"PSYM" %"PSYM" %"PSYM,
       DiskGravityPosition, DiskGravityPosition+1, DiskGravityPosition+2);
@@ -577,8 +531,8 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "ExternalGravityPosition = %"PSYM" %"PSYM" %"PSYM,
 		  ExternalGravityPosition, ExternalGravityPosition+1,
 		  ExternalGravityPosition+2);
-    ret += sscanf(line, "ExternalGravityOrientation = %"FSYM" %"FSYM" %"FSYM, 
-		  ExternalGravityOrientation, ExternalGravityOrientation+1, 
+    ret += sscanf(line, "ExternalGravityOrientation = %"FSYM" %"FSYM" %"FSYM,
+		  ExternalGravityOrientation, ExternalGravityOrientation+1,
 		  ExternalGravityOrientation+2);
 
     ret += sscanf(line, "SelfGravity           = %"ISYM, &SelfGravity);
@@ -590,7 +544,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "WritePotential        = %"ISYM, &WritePotential);
     ret += sscanf(line, "ParticleSubgridDepositMode  = %"ISYM, &ParticleSubgridDepositMode);
     ret += sscanf(line, "WriteAcceleration      = %"ISYM, &WriteAcceleration);
- 
+
     ret += sscanf(line, "DualEnergyFormalism     = %"ISYM, &DualEnergyFormalism);
     ret += sscanf(line, "DualEnergyFormalismEta1 = %"FSYM,
 		  &DualEnergyFormalismEta1);
@@ -616,7 +570,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
                   DrivenFlowVelocity, DrivenFlowVelocity+1, DrivenFlowVelocity+2);
     ret += sscanf(line, "DrivenFlowAutoCorrl = %"FSYM"%"FSYM"%"FSYM,
                      DrivenFlowAutoCorrl, DrivenFlowAutoCorrl+1, DrivenFlowAutoCorrl+2);
-    
+
     ret += sscanf(line, "UseSGSModel = %"ISYM, &UseSGSModel);
     ret += sscanf(line, "SGSFilterStencil = %"ISYM, &SGSFilterStencil);
     ret += sscanf(line, "SGSFilterWidth = %"FSYM, &SGSFilterWidth);
@@ -633,32 +587,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "SGScoeffSSb =%"FSYM, &SGScoeffSSb);
     ret += sscanf(line, "SGScoeffSSemf = %"FSYM, &SGScoeffSSemf);
 
-#ifdef USE_GRACKLE
-    /* Grackle chemistry parameters */
-    ret += sscanf(line, "with_radiative_cooling = %d",
-                  &grackle_data->with_radiative_cooling);
-    ret += sscanf(line, "use_volumetric_heating_rate = %d",
-                  &grackle_data->use_volumetric_heating_rate);
-    ret += sscanf(line, "use_specific_heating_rate = %d",
-                  &grackle_data->use_specific_heating_rate);
-    ret += sscanf(line, "self_shielding_method = %d",
-                  &grackle_data->self_shielding_method);
-    ret += sscanf(line, "H2_self_shielding = %d",
-                  &grackle_data->H2_self_shielding);
 
-    if (sscanf(line, "grackle_data_file = %s", dummy) == 1) {
-      grackle_data->grackle_data_file = dummy;
-      ret++;
-    }
-    ret += sscanf(line, "UVbackground = %d", &grackle_data->UVbackground);
-    ret += sscanf(line, "Compton_xray_heating = %d", 
-                  &grackle_data->Compton_xray_heating);
-    ret += sscanf(line, "LWbackground_intensity = %lf", 
-                  &grackle_data->LWbackground_intensity);
-    ret += sscanf(line, "LWbackground_sawtooth_suppression = %d",
-                  &grackle_data->LWbackground_sawtooth_suppression);
-    /********************************/
-#endif
     ret += sscanf(line, "RadiativeCooling = %"ISYM, &RadiativeCooling);
     ret += sscanf(line, "RadiativeCoolingModel = %"ISYM, &RadiativeCoolingModel);
     ret += sscanf(line, "GadgetEquilibriumCooling = %"ISYM, &GadgetEquilibriumCooling);
@@ -680,7 +609,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
       ret++;
     }
 
-    ret += sscanf(line, "CRModel = %"ISYM, &CRModel); 
+    ret += sscanf(line, "CRModel = %"ISYM, &CRModel);
     ret += sscanf(line, "CRDiffusion = %"ISYM, &CRDiffusion);
     ret += sscanf(line, "CRkappa = %"FSYM, &CRkappa);
     ret += sscanf(line, "CRCourantSafetyNumber = %"FSYM, &CRCourantSafetyNumber);
@@ -702,7 +631,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "AdjustUVBackgroundHighRedshift = %"ISYM, &AdjustUVBackgroundHighRedshift);
     ret += sscanf(line, "SetUVBAmplitude = %"FSYM, &SetUVBAmplitude);
     ret += sscanf(line, "SetHeIIHeatingScale = %"FSYM, &SetHeIIHeatingScale);
-    ret += sscanf(line, "RadiationFieldLevelRecompute = %"ISYM, &RadiationFieldLevelRecompute);    
+    ret += sscanf(line, "RadiationFieldLevelRecompute = %"ISYM, &RadiationFieldLevelRecompute);
     ret += sscanf(line, "RadiationShield = %"ISYM, &RadiationData.RadiationShield);
     ret += sscanf(line, "RadiationSpectrumNormalization = %"FSYM, &CoolData.f3);
     ret += sscanf(line, "RadiationSpectrumSlope = %"FSYM, &CoolData.alpha0);
@@ -732,18 +661,18 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "OutputTemperature = %"ISYM, &OutputTemperature);
     ret += sscanf(line, "OutputDustTemperature = %"ISYM, &OutputDustTemperature);
 
-    ret += sscanf(line, "OutputSmoothedDarkMatter = %"ISYM, 
+    ret += sscanf(line, "OutputSmoothedDarkMatter = %"ISYM,
 		  &OutputSmoothedDarkMatter);
-    ret += sscanf(line, "SmoothedDarkMatterNeighbors = %"ISYM, 
+    ret += sscanf(line, "SmoothedDarkMatterNeighbors = %"ISYM,
 		  &SmoothedDarkMatterNeighbors);
-    ret += sscanf(line, "OutputGriddedStarParticle = %"ISYM, 
+    ret += sscanf(line, "OutputGriddedStarParticle = %"ISYM,
 		  &OutputGriddedStarParticle);
 
     ret += sscanf(line, "ZEUSQuadraticArtificialViscosity = %"FSYM,
 		  &ZEUSQuadraticArtificialViscosity);
     ret += sscanf(line, "ZEUSLinearArtificialViscosity = %"FSYM,
 		  &ZEUSLinearArtificialViscosity);
- 
+
     ret += sscanf(line, "UseMinimumPressureSupport = %"ISYM,
 		  &UseMinimumPressureSupport);
     ret += sscanf(line, "MinimumPressureSupportParameter = %"FSYM,
@@ -759,7 +688,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "MustRefineParticlesCreateParticles = %"ISYM,
                   &MustRefineParticlesCreateParticles);
     ret += sscanf(line, "MustRefineParticlesLeftEdge  = %"PSYM" %"PSYM" %"PSYM,
-                  MustRefineParticlesLeftEdge, MustRefineParticlesLeftEdge+1, 
+                  MustRefineParticlesLeftEdge, MustRefineParticlesLeftEdge+1,
                   MustRefineParticlesLeftEdge+2);
     ret += sscanf(line, "MustRefineParticlesRightEdge = %"PSYM" %"PSYM" %"PSYM,
                   MustRefineParticlesRightEdge, MustRefineParticlesRightEdge+1,
@@ -790,7 +719,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 		    &dim, AvoidRefineRegionRightEdge[dim],
 		    AvoidRefineRegionRightEdge[dim]+1,
 		    AvoidRefineRegionRightEdge[dim]+2);
- 
+
     if (sscanf(line, "StaticRefineRegionLevel[%"ISYM"] = %"ISYM,&dim,&int_dummy) == 2){
       if (dim > MAX_STATIC_REGIONS-1) {
         ENZO_VFAIL("StaticRegion number %"ISYM" > MAX allowed\n", dim)
@@ -810,11 +739,11 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 		    &dim, StaticRefineRegionRightEdge[dim],
 		    StaticRefineRegionRightEdge[dim]+1,
 		    StaticRefineRegionRightEdge[dim]+2);
- 
+
     ret += sscanf(line, "ParallelRootGridIO = %"ISYM, &ParallelRootGridIO);
- 
+
     ret += sscanf(line, "ParallelParticleIO = %"ISYM, &ParallelParticleIO);
- 
+
     ret += sscanf(line, "Unigrid = %"ISYM, &Unigrid);
     ret += sscanf(line, "UnigridTranspose = %"ISYM, &UnigridTranspose);
     ret += sscanf(line, "NumberOfRootGridTilesPerDimensionPerProcessor = %"ISYM, &NumberOfRootGridTilesPerDimensionPerProcessor);
@@ -822,11 +751,11 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
                   &UserDefinedRootGridLayout[1], &UserDefinedRootGridLayout[2]);
 
     ret += sscanf(line, "PartitionNestedGrids = %"ISYM, &PartitionNestedGrids);
- 
+
     ret += sscanf(line, "ExtractFieldsOnly = %"ISYM, &ExtractFieldsOnly);
- 
+
     ret += sscanf(line, "CubeDumpEnabled = %"ISYM, &CubeDumpEnabled);
- 
+
     ret += sscanf(line, "Debug1 = %"ISYM, &debug1);
 
     ret += sscanf(line, "Debug2 = %"ISYM, &debug2);
@@ -851,43 +780,43 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
     ret += sscanf(line, "SlopeFlaggingFields = "
 		  " %"ISYM" %"ISYM" %"ISYM" %"ISYM" %"ISYM" %"ISYM" %"ISYM,
-		  SlopeFlaggingFields+0, 
+		  SlopeFlaggingFields+0,
 		  SlopeFlaggingFields+1,
-		  SlopeFlaggingFields+2, 
+		  SlopeFlaggingFields+2,
 		  SlopeFlaggingFields+3,
 		  SlopeFlaggingFields+4,
 		  SlopeFlaggingFields+5,
 		  SlopeFlaggingFields+6);
-    
-    ret += sscanf(line, "MinimumSlopeForRefinement = " 	  
+
+    ret += sscanf(line, "MinimumSlopeForRefinement = "
 		  " %"FSYM" %"FSYM" %"FSYM" %"FSYM" %"FSYM" %"FSYM" %"FSYM,
-	
+
 		  MinimumSlopeForRefinement+0,
 		  MinimumSlopeForRefinement+1,
 		  MinimumSlopeForRefinement+2,
 		  MinimumSlopeForRefinement+3,
-		  MinimumSlopeForRefinement+4,  
+		  MinimumSlopeForRefinement+4,
 		  MinimumSlopeForRefinement+5,
 		  MinimumSlopeForRefinement+6);
 
      ret += sscanf(line, "SecondDerivativeFlaggingFields = "
 		  " %"ISYM" %"ISYM" %"ISYM" %"ISYM" %"ISYM" %"ISYM" %"ISYM,
-		  SecondDerivativeFlaggingFields+0, 
+		  SecondDerivativeFlaggingFields+0,
 		  SecondDerivativeFlaggingFields+1,
-		  SecondDerivativeFlaggingFields+2, 
+		  SecondDerivativeFlaggingFields+2,
 		  SecondDerivativeFlaggingFields+3,
 		  SecondDerivativeFlaggingFields+4,
 		  SecondDerivativeFlaggingFields+5,
 		  SecondDerivativeFlaggingFields+6);
-    
-    ret += sscanf(line, "MinimumSecondDerivativeForRefinement = " 	  
+
+    ret += sscanf(line, "MinimumSecondDerivativeForRefinement = "
 		  " %"FSYM" %"FSYM" %"FSYM" %"FSYM" %"FSYM" %"FSYM" %"FSYM,
-	
+
 		  MinimumSecondDerivativeForRefinement+0,
 		  MinimumSecondDerivativeForRefinement+1,
 		  MinimumSecondDerivativeForRefinement+2,
 		  MinimumSecondDerivativeForRefinement+3,
-		  MinimumSecondDerivativeForRefinement+4,  
+		  MinimumSecondDerivativeForRefinement+4,
 		  MinimumSecondDerivativeForRefinement+5,
 		  MinimumSecondDerivativeForRefinement+6);
 
@@ -896,21 +825,21 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
     ret += sscanf(line, "MinimumOverDensityForRefinement  = "
 		  " %"FSYM" %"FSYM" %"FSYM" %"FSYM" %"FSYM" %"FSYM" %"FSYM,
-		  MinimumOverDensityForRefinement+0, 
+		  MinimumOverDensityForRefinement+0,
 		  MinimumOverDensityForRefinement+1,
-		  MinimumOverDensityForRefinement+2, 
+		  MinimumOverDensityForRefinement+2,
 		  MinimumOverDensityForRefinement+3,
-		  MinimumOverDensityForRefinement+4, 
+		  MinimumOverDensityForRefinement+4,
 		  MinimumOverDensityForRefinement+5,
 		  MinimumOverDensityForRefinement+6);
 
     ret += sscanf(line, "MinimumMassForRefinement  = "
 		  " %"FSYM" %"FSYM" %"FSYM" %"FSYM" %"FSYM" %"FSYM" %"FSYM,
-		  MinimumMassForRefinement+0, 
+		  MinimumMassForRefinement+0,
 		  MinimumMassForRefinement+1,
-		  MinimumMassForRefinement+2, 
+		  MinimumMassForRefinement+2,
 		  MinimumMassForRefinement+3,
-		  MinimumMassForRefinement+4, 
+		  MinimumMassForRefinement+4,
 		  MinimumMassForRefinement+5,
 		  MinimumMassForRefinement+6);
 
@@ -952,17 +881,17 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 		  &NumberOfParticleAttributes);
 
     /* read data which defines the boundary conditions */
- 
+
     ret += sscanf(line, "LeftFaceBoundaryCondition  = %"ISYM" %"ISYM" %"ISYM,
 		  MetaData.LeftFaceBoundaryCondition,
 		  MetaData.LeftFaceBoundaryCondition+1,
 		  MetaData.LeftFaceBoundaryCondition+2);
-    
+
      ret += sscanf(line, "RightFaceBoundaryCondition = %"ISYM" %"ISYM" %"ISYM,
  		  MetaData.RightFaceBoundaryCondition,
  		  MetaData.RightFaceBoundaryCondition+1,
  		  MetaData.RightFaceBoundaryCondition+2);
-  
+
     if (sscanf(line, "BoundaryConditionName         = %s", dummy) == 1)
       MetaData.BoundaryConditionName = dummy;
 
@@ -982,9 +911,9 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
       MetaData.InitialConditionsUUID = dummy;
       ret++;
     }
- 
+
     /* Check version number. */
- 
+
     if (sscanf(line, "VersionNumber = %"FSYM, &TempFloat) == 1) {
       ret++;
       if (fabs(TempFloat - VERSION) >= 1.0e-3 &&
@@ -1006,7 +935,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
      ret += sscanf(line, "GalaxySimulationPreWindTotalEnergy = %"FSYM,&GalaxySimulationPreWindTotalEnergy);
      ret += sscanf(line, "GalaxySimulationPreWindVelocity = %"PSYM" %"PSYM" %"PSYM,
          GalaxySimulationPreWindVelocity,GalaxySimulationPreWindVelocity+1,GalaxySimulationPreWindVelocity+2);
- 
+
     /* Read star particle parameters. */
 
     ret += sscanf(line, "StarMakerTypeIaSNe = %"ISYM,
@@ -1037,53 +966,53 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 		  &StarEnergyToThermalFeedback);
     ret += sscanf(line, "StarEnergyToStellarUV = %"FSYM, &StarEnergyToStellarUV);
     ret += sscanf(line, "StarEnergyToQuasarUV = %"FSYM, &StarEnergyToQuasarUV);
-    ret += sscanf(line, "StarFeedbackKineticFraction = %"FSYM, 
+    ret += sscanf(line, "StarFeedbackKineticFraction = %"FSYM,
     	&StarFeedbackKineticFraction);
-    ret += sscanf(line, "StarMakerExplosionDelayTime = %"FSYM, 
+    ret += sscanf(line, "StarMakerExplosionDelayTime = %"FSYM,
     	&StarMakerExplosionDelayTime);
     ret += sscanf(line, "StarFeedbackDistRadius = %"ISYM, &StarFeedbackDistRadius);
     ret += sscanf(line, "StarFeedbackDistCellStep = %"ISYM, &StarFeedbackDistCellStep);
     ret += sscanf(line, "StarMakerUseJeansMass = %"ISYM,
 		  &StarMakerUseJeansMass);
-    
-    ret += sscanf(line, "StarClusterUseMetalField = %"ISYM, 
+
+    ret += sscanf(line, "StarClusterUseMetalField = %"ISYM,
 		  &StarClusterUseMetalField);
-    ret += sscanf(line, "StarClusterMinDynamicalTime = %"FSYM, 
+    ret += sscanf(line, "StarClusterMinDynamicalTime = %"FSYM,
 		  &StarClusterMinDynamicalTime);
-    ret += sscanf(line, "StarClusterHeliumIonization = %"ISYM, 
+    ret += sscanf(line, "StarClusterHeliumIonization = %"ISYM,
 		  &StarClusterHeliumIonization);
-    ret += sscanf(line, "StarClusterUnresolvedModel = %"ISYM, 
+    ret += sscanf(line, "StarClusterUnresolvedModel = %"ISYM,
 		  &StarClusterUnresolvedModel);
-    ret += sscanf(line, "StarClusterIonizingLuminosity = %lf", 
+    ret += sscanf(line, "StarClusterIonizingLuminosity = %lf",
 		  &StarClusterIonizingLuminosity);
     ret += sscanf(line, "StarClusterSNEnergy = %lf", &StarClusterSNEnergy);
     ret += sscanf(line, "StarClusterSNRadius = %"FSYM, &StarClusterSNRadius);
-    ret += sscanf(line, "StarClusterFormEfficiency = %"FSYM, 
+    ret += sscanf(line, "StarClusterFormEfficiency = %"FSYM,
 		  &StarClusterFormEfficiency);
-    ret += sscanf(line, "StarClusterMinimumMass = %"FSYM, 
+    ret += sscanf(line, "StarClusterMinimumMass = %"FSYM,
 		  &StarClusterMinimumMass);
     ret += sscanf(line, "StarClusterCombineRadius = %"FSYM,
 		  &StarClusterCombineRadius);
     ret += sscanf(line, "StarClusterRegionLeftEdge = %"FSYM" %"FSYM" %"FSYM,
-		  StarClusterRegionLeftEdge, StarClusterRegionLeftEdge+1, 
+		  StarClusterRegionLeftEdge, StarClusterRegionLeftEdge+1,
 		  StarClusterRegionLeftEdge+2);
     ret += sscanf(line, "StarClusterRegionRightEdge = %"FSYM" %"FSYM" %"FSYM,
-		  StarClusterRegionRightEdge, StarClusterRegionRightEdge+1, 
+		  StarClusterRegionRightEdge, StarClusterRegionRightEdge+1,
 		  StarClusterRegionRightEdge+2);
 
     ret += sscanf(line, "PopIIIStarMass = %"FSYM, &PopIIIStarMass);
-    ret += sscanf(line, "PopIIIInitialMassFunction = %"ISYM, 
+    ret += sscanf(line, "PopIIIInitialMassFunction = %"ISYM,
 		  &PopIIIInitialMassFunction);
-    ret += sscanf(line, "PopIIIInitialMassFunctionSeed = %"ISYM, 
+    ret += sscanf(line, "PopIIIInitialMassFunctionSeed = %"ISYM,
 		  &PopIIIInitialMassFunctionSeed);
-    ret += sscanf(line, "PopIIIInitialMassFunctionCalls = %"ISYM, 
+    ret += sscanf(line, "PopIIIInitialMassFunctionCalls = %"ISYM,
 		  &PopIIIInitialMassFunctionCalls);
     ret += sscanf(line, "PopIIIMassRange = %"FSYM" %"FSYM,
 		  &PopIIILowerMassCutoff, &PopIIIUpperMassCutoff);
-    ret += sscanf(line, "PopIIIInitialMassFunctionSlope = %"FSYM, 
+    ret += sscanf(line, "PopIIIInitialMassFunctionSlope = %"FSYM,
 		  &PopIIIInitialMassFunctionSlope);
     ret += sscanf(line, "PopIIIBlackHoles = %"ISYM, &PopIIIBlackHoles);
-    ret += sscanf(line, "PopIIIBHLuminosityEfficiency = %"FSYM, 
+    ret += sscanf(line, "PopIIIBHLuminosityEfficiency = %"FSYM,
 		  &PopIIIBHLuminosityEfficiency);
     ret += sscanf(line, "PopIIIOverDensityThreshold = %"FSYM,
 		  &PopIIIOverDensityThreshold);
@@ -1092,13 +1021,13 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "PopIIIMetalCriticalFraction = %"FSYM,
 		  &PopIIIMetalCriticalFraction);
     ret += sscanf(line, "PopIIISupernovaRadius = %"FSYM, &PopIIISupernovaRadius);
-    ret += sscanf(line, "PopIIISupernovaUseColour = %"ISYM, 
+    ret += sscanf(line, "PopIIISupernovaUseColour = %"ISYM,
 		  &PopIIISupernovaUseColour);
     ret += sscanf(line, "PopIIISupernovaMustRefine = %"ISYM,
 		  &PopIIISupernovaMustRefine);
     ret += sscanf(line, "PopIIISupernovaMustRefineResolution = %"ISYM,
 		  &PopIIISupernovaMustRefineResolution);
-    ret += sscanf(line, "PopIIIHeliumIonization = %"ISYM, 
+    ret += sscanf(line, "PopIIIHeliumIonization = %"ISYM,
 		  &PopIIIHeliumIonization);
 
     ret += sscanf(line, "PopIIIColorDensityThreshold = %"FSYM,
@@ -1202,8 +1131,8 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "AngularVelocity = %"FSYM, &AngularVelocity);
     ret += sscanf(line, "VelocityGradient = %"FSYM, &VelocityGradient);
     ret += sscanf(line, "ShearingVelocityDirection = %"ISYM, &ShearingVelocityDirection);
-    ret += sscanf(line, "ShearingBoxProblemType = %"ISYM, &ShearingBoxProblemType);  
-    
+    ret += sscanf(line, "ShearingBoxProblemType = %"ISYM, &ShearingBoxProblemType);
+
 
 #ifdef STAGE_INPUT
     sscanf(line, "LocalPath = %s\n", LocalPath);
@@ -1227,11 +1156,11 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
     ret += sscanf(line, "InlineHaloFinder = %"ISYM, &InlineHaloFinder);
     ret += sscanf(line, "HaloFinderSubfind = %"ISYM, &HaloFinderSubfind);
-    ret += sscanf(line, "HaloFinderOutputParticleList = %"ISYM, 
+    ret += sscanf(line, "HaloFinderOutputParticleList = %"ISYM,
 		  &HaloFinderOutputParticleList);
-    ret += sscanf(line, "HaloFinderRunAfterOutput = %"ISYM, 
+    ret += sscanf(line, "HaloFinderRunAfterOutput = %"ISYM,
 		  &HaloFinderRunAfterOutput);
-    ret += sscanf(line, "HaloFinderLinkingLength = %"FSYM, 
+    ret += sscanf(line, "HaloFinderLinkingLength = %"FSYM,
 		  &HaloFinderLinkingLength);
     ret += sscanf(line, "HaloFinderMinimumSize = %"ISYM, &HaloFinderMinimumSize);
     ret += sscanf(line, "HaloFinderCycleSkip = %"ISYM, &HaloFinderCycleSkip);
@@ -1244,7 +1173,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
 
     /* Sink particles (for present day star formation) & winds */
-    ret += sscanf(line, "SinkMergeDistance     = %"FSYM, &SinkMergeDistance); 
+    ret += sscanf(line, "SinkMergeDistance     = %"FSYM, &SinkMergeDistance);
     ret += sscanf(line, "SinkMergeMass         = %"FSYM, &SinkMergeMass);
     ret += sscanf(line, "StellarWindFeedback   = %"ISYM, &StellarWindFeedback);
     ret += sscanf(line, "StellarWindTurnOnMass = %"FSYM, &StellarWindTurnOnMass);
@@ -1257,7 +1186,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
     /* Read MHD Paramters */
     ret += sscanf(line, "UsePoissonDivergenceCleaning = %"ISYM"", &UsePoissonDivergenceCleaning);
-    ret += sscanf(line, "PoissonDivergenceCleaningBoundaryBuffer = %"ISYM"", 
+    ret += sscanf(line, "PoissonDivergenceCleaningBoundaryBuffer = %"ISYM"",
                         &PoissonDivergenceCleaningBoundaryBuffer);
     ret += sscanf(line, "PoissonDivergenceCleaningThreshold = %"FSYM, &PoissonDivergenceCleaningThreshold);
     ret += sscanf(line, "PoissonApproximationThreshold = %"FSYM, &PoissonApproximationThreshold);
@@ -1266,7 +1195,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "UseDivergenceCleaning = %"ISYM"", &UsePoissonDivergenceCleaning);
     ret += sscanf(line, "DivergenceCleaningBoundaryBuffer = %"ISYM"", &PoissonDivergenceCleaningBoundaryBuffer);
     ret += sscanf(line, "DivergenceCleaningThreshold = %"FSYM, &PoissonDivergenceCleaningThreshold);
-   
+
 
     ret += sscanf(line, "AngularVelocity = %"FSYM, &AngularVelocity);
     ret += sscanf(line, "VelocityGradient = %"FSYM, &VelocityGradient);
@@ -1279,7 +1208,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "Theta_Limiter = %"FSYM, &Theta_Limiter);
     ret += sscanf(line, "UseFloor = %"ISYM"", &UseFloor);
     ret += sscanf(line, "UseViscosity = %"ISYM"", &UseViscosity);
-    ret += sscanf(line, "ViscosityCoefficient = %"FSYM, &ViscosityCoefficient);  
+    ret += sscanf(line, "ViscosityCoefficient = %"FSYM, &ViscosityCoefficient);
     ret += sscanf(line, "UseAmbipolarDiffusion = %"ISYM"", &UseAmbipolarDiffusion);
     ret += sscanf(line, "UseResistivity = %"ISYM"", &UseResistivity);
     ret += sscanf(line, "SmallRho = %"FSYM, &SmallRho);
@@ -1356,7 +1285,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
     ret += sscanf(line,"tiny_pressure = %"FSYM,&tiny_pressure);
     ret += sscanf(line,"MHD_CT_Method = %"ISYM,&MHD_CT_Method);
-		  
+
     ret += sscanf(line,"NumberOfGhostZones = %"ISYM,&NumberOfGhostZones);
     ret += sscanf(line,"MHD_ProjectB = %"ISYM,&MHD_ProjectB);
     ret += sscanf(line,"MHD_ProjectE = %"ISYM,&MHD_ProjectE);
@@ -1396,7 +1325,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 		  ParticleSplitterCenterRegion+2, ParticleSplitterCenterRegion+3);
     ret += sscanf(line, "ResetMagneticField = %"ISYM,
 		  &ResetMagneticField);
-    ret += sscanf(line, "ResetMagneticFieldAmplitude  =  %"GSYM" %"GSYM" %"GSYM, 
+    ret += sscanf(line, "ResetMagneticFieldAmplitude  =  %"GSYM" %"GSYM" %"GSYM,
 		  ResetMagneticFieldAmplitude,
 		  ResetMagneticFieldAmplitude+1,
 		  ResetMagneticFieldAmplitude+2);
@@ -1415,7 +1344,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "SmartStarBHThermalFeedback  = %"ISYM, &SmartStarBHThermalFeedback);
     ret += sscanf(line, "SmartStarBHRadiativeFeedback = %"ISYM, &SmartStarBHRadiativeFeedback);
     ret += sscanf(line, "SmartStarStellarRadiativeFeedback = %"ISYM, &SmartStarStellarRadiativeFeedback);
-    
+
     ret += sscanf(line, "SmartStarFeedbackEnergyCoupling       = %"FSYM, &SmartStarFeedbackEnergyCoupling);
     ret += sscanf(line, "SmartStarFeedbackJetsThresholdMass    = %"FSYM, &SmartStarFeedbackJetsThresholdMass);
     ret += sscanf(line, "SmartStarSMSLifetime                  = %"FSYM, &SmartStarSMSLifetime);
@@ -1431,15 +1360,15 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line,"MagneticSupernovaDuration = %"FSYM, &MagneticSupernovaDuration);
 
     /* If the dummy char space was used, then make another. */
- 
+
     if (*dummy != 0) {
       dummy = new char[MAX_LINE_LENGTH];
       dummy[0] = 0;
       ret++;
     }
- 
+
     /* check to see if the line belongs to one of the test problems */
- 
+
     if (strstr(line, "ShockTube")           ) ret++;
     if (strstr(line, "WavePool" )           ) ret++;
     if (strstr(line, "ShockPool")           ) ret++;
@@ -1471,7 +1400,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     if (strstr(line, "TracerParticleCreation")) ret++;
     if (strstr(line, "TurbulenceSimulation")) ret++;
     if (strstr(line, "ProtostellarCollapse")) ret++;
-    if (strstr(line, "GalaxySimulation") 
+    if (strstr(line, "GalaxySimulation")
 			&& !strstr(line,"RPSWind") && !strstr(line,"PreWind") ) ret++;
     if (strstr(line, "AgoraRestart")) ret++;
     if (strstr(line, "ConductionTest")) ret++;
@@ -1481,7 +1410,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     if (strstr(line, "OneZoneFreefall")) ret++;
     if (strstr(line, "ShearingBox")) ret++;
     if (strstr(line, "PoissonSolverTest")) ret++;
-    /* 7.22.10 - CBH: Added 5 following lines to avoid runtime warnings from 
+    /* 7.22.10 - CBH: Added 5 following lines to avoid runtime warnings from
     extra params previously added to code (but not read_params) by others.*/
     if (strstr(line, "Cloudy")              ) ret++;
     if (strstr(line, "IsothermalSoundSpeed")) ret++;
@@ -1504,11 +1433,11 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     if (strstr(line, "\"\"\"")              ) comment_count++;
 
     /* if the line is suspicious, issue a warning */
- 
+
     if (ret == 0 && strstr(line, "=") != NULL && line[0] != '#')
       if (MyProcessorNumber == ROOT_PROCESSOR)
 	fprintf(stderr, "warning: the following parameter line was not interpreted:\n%s", line);
- 
+
   }
 
   // Enable the active particles that were selected.
@@ -1520,7 +1449,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     delete [] active_particle_types[i];
   }
   delete [] active_particle_types;
-  
+
   // HierarchyFile IO sanity check
 
   // Note that although I only do not allow HierarchyFileInputFormat=2
@@ -1531,8 +1460,8 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
   if ((HierarchyFileOutputFormat < 0) || (HierarchyFileOutputFormat > 2))
     ENZO_FAIL("Invalid HierarchyFileOutputFormat. Must be 0 (HDF5), 1 (ASCII), or 2 (both).")
-  
-  // While we're examining the hierarchy, check that the MultiRefinedRegion doesn't demand more refinement that we've got                                                                                     
+
+  // While we're examining the hierarchy, check that the MultiRefinedRegion doesn't demand more refinement that we've got
   for (int ireg = 0; ireg < MAX_STATIC_REGIONS; ireg++)
     if (MultiRefineRegionGeometry[ireg] >= 0)
       if (MultiRefineRegionMaximumLevel[ireg] > MaximumRefinementLevel)
@@ -1541,12 +1470,12 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
 
   /* clean up */
- 
+
   delete [] dummy;
   rewind(fptr);
 
 
-/*  If stochastic forcing is used, initialize the object 
+/*  If stochastic forcing is used, initialize the object
  *  but only if it is not a fresh simulation*/
   if (DrivenFlowProfile && MetaData.Time != 0.) {
     for (dim = 0; dim < MetaData.TopGridRank; dim++)
@@ -1566,15 +1495,15 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
   /* In order to use filtered fields we need additional ghost zones */
   if (SGSFilterStencil/2 + 2 > NumberOfGhostZones)
     ENZO_FAIL("SGS filtering needs additional ghost zones!\n");
-  
+
   // all these models are calculated based on the partial derivatives of
   // the primitive quantities
   if (SGScoeffERS2M2Star != 0. ||
       SGScoeffEVStarEnS2Star != 0. ||
-      SGScoeffEnS2StarTrace != 0. || 
-      SGScoeffNLemfCompr != 0. || 
-      SGScoeffNLu != 0. || 
-      SGScoeffNLuNormedEnS2Star != 0. || 
+      SGScoeffEnS2StarTrace != 0. ||
+      SGScoeffNLemfCompr != 0. ||
+      SGScoeffNLu != 0. ||
+      SGScoeffNLuNormedEnS2Star != 0. ||
       SGScoeffNLb != 0.)
 
       SGSNeedJacobians = 1;
@@ -1601,7 +1530,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
      parameters aren't used for PPM_LagrangeRemap and Zeus. */
 
   if (HydroMethod == PPM_DirectEuler) {
-    if (RiemannSolver == INT_UNDEFINED) 
+    if (RiemannSolver == INT_UNDEFINED)
       RiemannSolver = TwoShock;
     if (ReconstructionMethod == INT_UNDEFINED)
       ReconstructionMethod = PPM;
@@ -1617,14 +1546,14 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     }
     if (RiemannSolver == -HLL) RiemannSolver = HLL;
   } else if (HydroMethod == HD_RK || HydroMethod == MHD_RK) {
-    if (RiemannSolver == INT_UNDEFINED) 
+    if (RiemannSolver == INT_UNDEFINED)
       RiemannSolver = HLL;
     if (ReconstructionMethod == INT_UNDEFINED)
       ReconstructionMethod = PLM;
   }
 
   else if (HydroMethod == MHD_Li )
-    if (RiemannSolver == INT_UNDEFINED) 
+    if (RiemannSolver == INT_UNDEFINED)
         RiemannSolver = HLLD;
     if (ReconstructionMethod == INT_UNDEFINED)
         ReconstructionMethod = PLM;
@@ -1658,7 +1587,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
       if(MyProcessorNumber == ROOT_PROCESSOR ) {
 	fprintf(stderr, "WARNING:  UseGasDrag != 0 yet HM=MHD_RK \n");
 	fprintf(stderr, "WARNING:  setting UseGasDrag = 0. I.e no Gas drag included. \n");
-	UseGasDrag = 0; 
+	UseGasDrag = 0;
       }
     }
 
@@ -1669,9 +1598,9 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
   for (i = 0; i < MAX_STATIC_REGIONS; i++)
     if (StaticRefineRegionLevel[i] != INT_UNDEFINED)
       CosmologySimulationNumberOfInitialGrids++;
- 
+
   /* If we have turned on Comoving coordinates, read cosmology parameters. */
- 
+
   if (ComovingCoordinates) {
 
     // Always output temperature in cosmology runs
@@ -1693,8 +1622,8 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
   // make sure that MHD is turned on if we're trying to use anisotropic conduction.
   // if not, alert user.
   if(AnisotropicConduction==TRUE && UseMHD==0){
-    ENZO_FAIL("AnisotropicConduction can only be used if MHD is turned on!\n");
-  }  
+    ENZO_FAIL("AnisotropicConduction can only be used if MHD is turnedf on!\n");
+  }
   if(AnisotropicConduction==TRUE && MetaData.TopGridRank < 2){
     ENZO_FAIL("AnisotropicConduction can only be used if TopGridRank is >= 2!\n");
   }
@@ -1705,11 +1634,11 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
 
   /*
-    if (EOSType == 3) // an isothermal equation of state implies the adiabatic index = 1 
-    Gamma = 1; 
+    if (EOSType == 3) // an isothermal equation of state implies the adiabatic index = 1
+    Gamma = 1;
   */
 
-  /* convert MustRefineParticlesMinimumMass from a mass into a density, 
+  /* convert MustRefineParticlesMinimumMass from a mass into a density,
      ASSUMING CUBE simulation space */
     MustRefineParticlesMinimumMass /= POW(1/(float(MetaData.TopGridDims[0])
 				       *POW(float(RefineBy), float(MustRefineParticlesRefineToLevel))),3);
@@ -1717,20 +1646,20 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
     /* Use Physical units stuff */
 
-  float DensityUnits = 1.0, LengthUnits = 1.0, TemperatureUnits = 1.0, 
+  float DensityUnits = 1.0, LengthUnits = 1.0, TemperatureUnits = 1.0,
     TimeUnits = 1.0, VelocityUnits = 1.0, PressureUnits = 1.0;
   double MassUnits = 1.0;
   if (UsePhysicalUnit) {
-    GetUnits(&DensityUnits, &LengthUnits, &TemperatureUnits, &TimeUnits, &VelocityUnits, 
+    GetUnits(&DensityUnits, &LengthUnits, &TemperatureUnits, &TimeUnits, &VelocityUnits,
 	     &MassUnits, MetaData.Time);
     PressureUnits = DensityUnits*pow(VelocityUnits,2);
     /*IMOPORTANT: If change anything here must change both equivilant parts in WriteParameterFile.C as well */
 
     /* Change input physical parameters into code units */
-    MustRefineParticlesMinimumMass /= MassUnits; 
+    MustRefineParticlesMinimumMass /= MassUnits;
     StarMakerOverDensityThreshold /= DensityUnits;
     //  StarEnergyFeedbackRate = StarEnergyFeedbackRate/pow(LengthUnits,2)*pow(TimeUnits,3);
-    
+
     if (SinkMergeDistance > 1.0)
       SinkMergeDistance /= LengthUnits;
     //printf(" \n SinkMergeDistance = %"FSYM"\n \n", SinkMergeDistance);
@@ -1744,7 +1673,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     if (debug && (HydroMethod == HD_RK || HydroMethod == MHD_RK))
       printf("smallrho=%g, smallp=%g, smalleint=%g, DensityUnits = %g, PressureUnits=%g, MaximumAlvenSpeed=%g\n",
 	     SmallRho, SmallP, SmallEint,DensityUnits, PressureUnits, MaximumAlvenSpeed);
-    for (int i = 0; i < MAX_FLAGGING_METHODS; i++) 
+    for (int i = 0; i < MAX_FLAGGING_METHODS; i++)
       if (MinimumMassForRefinement[i] != FLOAT_UNDEFINED) {
 	MinimumMassForRefinement[i] /= MassUnits;
       }
@@ -1755,21 +1684,21 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
   }
 
-  /* For !restart, this only ruins the units because MinimumOverDensityForRefinement is already 
+  /* For !restart, this only ruins the units because MinimumOverDensityForRefinement is already
      set in SetDefaultGlobalValues and not FLOAT_UNDEFINED.
-     For restart, MinimumOverDensityForRefinement is not even needs to be read because only 
-     MinimumMassForRefinement is used for CellFlagging.  
+     For restart, MinimumOverDensityForRefinement is not even needs to be read because only
+     MinimumMassForRefinement is used for CellFlagging.
      So, why did we have to do this in the first place?  - Ji-hoon Kim in Apr.2010
      (The counterpart in WriteParameterFile is also commented out) */   //#####
 
   /*
-  if (!ComovingCoordinates && UsePhysicalUnit) 
-    for (int i = 0; i < MAX_FLAGGING_METHODS; i++) 
+  if (!ComovingCoordinates && UsePhysicalUnit)
+    for (int i = 0; i < MAX_FLAGGING_METHODS; i++)
       if (MinimumOverDensityForRefinement[i] != FLOAT_UNDEFINED) {
 	MinimumOverDensityForRefinement[i] /= DensityUnits;
       }
   */
-  
+
   /* If TimeType is 0 or 1 for RefineRegion, MustRefineRegion, or CoolingRefineRegion, read in the input file. */
   if ((RefineRegionTimeType == 0) || (RefineRegionTimeType == 1)
       || (MustRefineRegionTimeType == 0) || (MustRefineRegionTimeType == 1)
@@ -1785,94 +1714,23 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
 
 #ifdef USE_GRACKLE
-  /* If using Grackle chemistry and cooling library, override all other 
-     cooling machinery and do a translation of some of the parameters. */
-  if (use_grackle == TRUE) {
-    // grackle_data->with_radiative_cooling already set
-    // grackle_data->grackle_data_file already set
-    // grackle_data->UVbackground already set
-    // grackle_data->Compton_xray_heating already set
-    // grackle_data->LWbackground_intensity already set
-    // grackle_data->LWbackground_sawtooth_suppression already set
-    grackle_data->use_grackle                    = (Eint32) use_grackle;
-    grackle_data->Gamma                          = (double) Gamma;
-    grackle_data->primordial_chemistry           = (Eint32) MultiSpecies;
-    grackle_data->metal_cooling                  = (Eint32) MetalCooling;
-    grackle_data->h2_on_dust                     = (Eint32) H2FormationOnDust;
-    grackle_data->cmb_temperature_floor          = (Eint32) CloudyCoolingData.CMBTemperatureFloor;
-    grackle_data->three_body_rate                = (Eint32) ThreeBodyRate;
-    grackle_data->cie_cooling                    = (Eint32) CIECooling;
-    grackle_data->h2_optical_depth_approximation = (Eint32) H2OpticalDepthApproximation;
-    grackle_data->photoelectric_heating          = (Eint32) PhotoelectricHeating;
-    grackle_data->photoelectric_heating_rate     = (double) PhotoelectricHeatingRate;
-    grackle_data->NumberOfTemperatureBins        = (Eint32) CoolData.NumberOfTemperatureBins;
-    grackle_data->CaseBRecombination             = (Eint32) RateData.CaseBRecombination;
-    grackle_data->TemperatureStart               = (double) CoolData.TemperatureStart;
-    grackle_data->TemperatureEnd                 = (double) CoolData.TemperatureEnd;
-    grackle_data->NumberOfDustTemperatureBins    = (Eint32) RateData.NumberOfDustTemperatureBins;
-    grackle_data->DustTemperatureStart           = (double) RateData.DustTemperatureStart;
-    grackle_data->DustTemperatureEnd             = (double) RateData.DustTemperatureEnd;
-    grackle_data->HydrogenFractionByMass         = (double) CoolData.HydrogenFractionByMass;
-    grackle_data->DeuteriumToHydrogenRatio       = (double) CoolData.DeuteriumToHydrogenRatio;
-    grackle_data->SolarMetalFractionByMass       = (double) CoolData.SolarMetalFractionByMass;
-    grackle_data->UVbackground_redshift_on       = (double) CoolData.RadiationRedshiftOn;
-    grackle_data->UVbackground_redshift_off      = (double) CoolData.RadiationRedshiftOff;
-    grackle_data->UVbackground_redshift_fullon   = (double) CoolData.RadiationRedshiftFullOn;
-    grackle_data->UVbackground_redshift_drop     = (double) CoolData.RadiationRedshiftDropOff;
-    grackle_data->use_radiative_transfer         = (Eint32) RadiativeTransfer;
-    // grackle_data->radiative_transfer_coupled_rate_solver set in RadiativeTransferReadParameters
-    // grackle_data->radiative_transfer_hydrogen_only set in RadiativeTransferReadParameters
-    
-    // Initialize units structure.
-    FLOAT a_value, dadt;
-    a_value = 1.0;
-    code_units grackle_units;
-    grackle_units.a_units = 1.0;
-    if (GetUnits(&DensityUnits, &LengthUnits, &TemperatureUnits,
-                 &TimeUnits, &VelocityUnits, MetaData.Time) == FAIL) {
-      ENZO_FAIL("Error in GetUnits.\n");
-    }
-    if (ComovingCoordinates) {
-      if (CosmologyComputeExpansionFactor(MetaData.Time, &a_value, 
-                                          &dadt) == FAIL) {
-        ENZO_FAIL("Error in CosmologyComputeExpansionFactors.\n");
-      }
-      grackle_units.a_units            = (double) (1.0 / (1.0 + InitialRedshift));
-    }
-    grackle_units.comoving_coordinates = (Eint32) ComovingCoordinates;
-    grackle_units.density_units        = (double) DensityUnits;
-    grackle_units.length_units         = (double) LengthUnits;
-    grackle_units.time_units           = (double) TimeUnits;
-    grackle_units.velocity_units       = (double) VelocityUnits;
-    grackle_units.a_value              = (double) a_value;
 
-    // Initialize chemistry structure.
-    if (initialize_chemistry_data(&grackle_units) == FAIL) {
-      ENZO_FAIL("Error in Grackle initialize_chemistry_data.\n");
-    }
+  // Check if Grackle is being used, and read in parameters if so
+  if (GrackleReadParameters(fptr, MetaData.Time) == FAIL){
+    ENZO_FAIL("Error in GrackleReadParameters.\n");
+  }
+  rewind(fptr);
 
-    // Need to set these after initialize_chemistry_data since
-    // that function sets them automatically based on the tables.
-    if (FinalRedshift < grackle_data->UVbackground_redshift_off) {
-      grackle_data->UVbackground_redshift_off = FinalRedshift;
-      grackle_data->UVbackground_redshift_drop = FinalRedshift;
-    }
-
-  }  // if (grackle_data->use_grackle == TRUE)
-
-  else {
-#else
-    if (use_grackle == TRUE) {
-      ENZO_FAIL("Error: Enzo must be compiled with 'make grackle-yes' to run with use_grackle = 1.\n");
-    }
+  if (use_grackle == FALSE) {
+    /* If Grackle is not being used, handle other possible cooling / chemistry settings  */
 #endif // USE_GRACKLE
 
     /* If GadgetEquilibriumCooling == TRUE, we don't want MultiSpecies
-       or RadiationFieldType to be on - both are taken care of in
-       the Gadget cooling routine.  Therefore, we turn them off!
-       Also, initialize the Gadget equilibrium cooling data. */
+    or RadiationFieldType to be on - both are taken care of in
+    the Gadget cooling routine.  Therefore, we turn them off!
+    Also, initialize the Gadget equilibrium cooling data. */
 
-    if(GadgetEquilibriumCooling == TRUE){
+    if (GadgetEquilibriumCooling == TRUE){
 
       if(MyProcessorNumber == ROOT_PROCESSOR ) {
         fprintf(stderr, "WARNING:  GadgetEquilibriumCooling = 1.  Forcing\n");
@@ -1887,7 +1745,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
       // initialize Gadget equilibrium cooling
       if (InitializeGadgetEquilibriumCoolData(MetaData.Time) == FAIL) {
         ENZO_FAIL("Error in InitializeGadgetEquilibriumCoolData.");
-      } 
+      }
     }
 
     /* If set, initialize the RadiativeCooling and RateEquations data. */
@@ -1897,8 +1755,8 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
         ENZO_FAIL("Error in InitializeRateData.");
       }
     }
- 
-    if (MultiSpecies             == 0 && 
+
+    if (MultiSpecies             == 0 &&
         MetalCooling             == 0 &&
         GadgetEquilibriumCooling == 0 &&
         RadiativeCooling          > 0) {
@@ -1908,30 +1766,30 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     }
 
     /* If using the internal radiation field, initialize it. */
- 
-    if (RadiationFieldType == 11) 
-      RadiationData.RadiationShield = TRUE; 
+
+    if (RadiationFieldType == 11)
+      RadiationData.RadiationShield = TRUE;
     else if (RadiationFieldType == 10)
-      RadiationData.RadiationShield = FALSE; 
+      RadiationData.RadiationShield = FALSE;
 
     if ((RadiationFieldType >= 10 && RadiationFieldType <= 11) ||
         RadiationData.RadiationShield == TRUE)
       if (InitializeRadiationFieldData(MetaData.Time) == FAIL) {
 	ENZO_FAIL("Error in InitializeRadiationFieldData.");
       }
- 
+
 #ifdef USE_GRACKLE
-  } // else (if Grackle == TRUE)
+  } // else (if Grackle == False )
 #endif
 
-  /* If using MBHFeedback = 2 to 5 (Star->FeedbackFlag = MBH_JETS), 
+  /* If using MBHFeedback = 2 to 5 (Star->FeedbackFlag = MBH_JETS),
      you need MBHParticleIO for angular momentum */
 
-  if (MBHFeedback >= 2 && MBHFeedback <= 5) 
+  if (MBHFeedback >= 2 && MBHFeedback <= 5)
     MBHParticleIO = TRUE;
 
   /* Turn off DualEnergyFormalism for zeus hydro (and a few other things). */
- 
+
   if (HydroMethod == Zeus_Hydro) {
     ConservativeInterpolation = FALSE;
     DualEnergyFormalism       = FALSE;
@@ -1943,7 +1801,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
   /* Set some star feedback parameters. */
 
-  if ((STARFEED_METHOD(NORMAL_STAR) || STARFEED_METHOD(UNIGRID_STAR)) && 
+  if ((STARFEED_METHOD(NORMAL_STAR) || STARFEED_METHOD(UNIGRID_STAR)) &&
       (StarFeedbackDistRadius > 0)) {
 
     // Calculate number of cells in the shape over which to distribute feedback.
@@ -1967,7 +1825,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 	      StarFeedbackDistTotalCells);
     }
   }
- 
+
   /* For rk_hydro, we need to set some variables */
 
   if (DualEnergyFormalism) {
@@ -2003,7 +1861,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
   MaximumGravityRefinementLevel =
     min(MaximumGravityRefinementLevel, MaximumRefinementLevel);
- 
+
   /* If MultiSpecies < 2, we can't simulate Pop III star formation */
 
   if (MultiSpecies < 2 && STARMAKE_METHOD(POP3_STAR)) {
@@ -2015,7 +1873,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
   /* Use the value in MaximumParticleRefinementLevel to set the smoothing
      radius for the particles, to be used to Grid_DepositPositions. */
- 
+
   if (MaximumParticleRefinementLevel >= 0)
     DepositPositionsParticleSmoothRadius =
       (DomainRightEdge[0] - DomainLeftEdge[0])/
@@ -2023,14 +1881,14 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
        POW(float(RefineBy), float(MaximumParticleRefinementLevel)));
   else
     DepositPositionsParticleSmoothRadius = 0;
- 
-  
+
+
 
 //  PPMDiffusion causes an out-of-bounds condition as currently written
 //  The following is an over-ride to force PPMDiffusion OFF. This has
 //  been fixed in this latest version (AK).
 
-//  NOTE: The fix keeps the code from crashing, but is not a proper 
+//  NOTE: The fix keeps the code from crashing, but is not a proper
 //  implementation of PPM diffusion.  The reason why is that Enzo typically
 //  uses 3 ghost zones, and the correct PPM diffusion implementation requires
 //  4 parameters.  SO, you should not use this parameter for, e.g., cosmology
@@ -2048,7 +1906,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
       printf("WARNING! Setting MetaData.PPMDiffusionParameter = 0\n");
     MetaData.PPMDiffusionParameter = 0;
   }
- 
+
   if (PartitionNestedGrids == 1) {
     if (MyProcessorNumber == ROOT_PROCESSOR)
       printf("WARNING! PartitionNestedGrids = 1 forces Parallel IO = 1\n");
@@ -2066,7 +1924,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
   if ((MetaData.GravityBoundary != TopGridPeriodic) &&
       (UnigridTranspose)) {
     /* it turns out that Robert Harkness' unigrid transpose stuff is incompatible with the top
-       grid isolated gravity boundary conditions.  I'm not 100 percent sure why this is - in the 
+       grid isolated gravity boundary conditions.  I'm not 100 percent sure why this is - in the
        meantime, just double-check to make sure that if one tries to use the isolated boundary
        conditions when the unigrid transpose stuff is on, the code crashes loudly.
        -- BWO, 26 June 2008 */
@@ -2081,7 +1939,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
   if (ABS(MetaData.dtRestartDump - 3600.0*5) / (3600.0*5) < tol &&
       ABS(MetaData.TimeLastRestartDump) < tol) {
     if (MyProcessorNumber == ROOT_PROCESSOR)
-      fprintf(stderr, 
+      fprintf(stderr,
 	      "==================================================\n"
 	      "-> Turning off restart dumps because the previous\n"
 	      "default was set to 5 hours but not used.  To avoid this warning,\n"
@@ -2096,12 +1954,12 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
   int method;
   bool TurnOnParticleMassRefinement = false;
-  for (method = 0; method < MAX_FLAGGING_METHODS; method++) 
+  for (method = 0; method < MAX_FLAGGING_METHODS; method++)
     if (CellFlaggingMethod[method] == 8) {
       TurnOnParticleMassRefinement = true;
       break;
     }
-  for (method = 0; method < MAX_FLAGGING_METHODS; method++) 
+  for (method = 0; method < MAX_FLAGGING_METHODS; method++)
     if (CellFlaggingMethod[method] == 4) {
       TurnOnParticleMassRefinement = false;
       break;
@@ -2148,7 +2006,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
   if (OutputParticleTypeGrouping && (!ParticleTypeInFile)) {
     OutputParticleTypeGrouping = FALSE;
   }
- 
+
   //  if (WritePotential && ComovingCoordinates && SelfGravity) {
   if (WritePotential && SelfGravity) {
     CopyGravPotential = TRUE;
@@ -2158,24 +2016,24 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
   MetaData.OutputsLeftBeforeExit = MetaData.NumberOfOutputsBeforeExit;
 
   if (MyProcessorNumber == ROOT_PROCESSOR) {
- 
+
     if ( MetaData.GlobalDir != NULL ) {
       fprintf(stderr, "Output to Global Dir %s\n", MetaData.GlobalDir);
     }
- 
+
     if ( MetaData.LocalDir != NULL ) {
       fprintf(stderr, "Output to Local Dir %s\n", MetaData.LocalDir);
     }
 
   }
- 
+
   if ( (MetaData.GlobalDir != NULL) && (MetaData.LocalDir != NULL) ) {
     ENZO_FAIL("Cannot select GlobalDir AND LocalDir!\n");
   }
- 
+
   char *cwd_buffer = new char[MAX_LINE_LENGTH];
   size_t cwd_buffer_len = MAX_LINE_LENGTH;
- 
+
   if ( (MetaData.GlobalDir == NULL) && (MetaData.LocalDir == NULL) ) {
     /*if(getcwd(cwd_buffer, cwd_buffer_len) == NULL) {
       fprintf(stderr, "GETCWD call FAILED\n");
@@ -2184,7 +2042,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
       fprintf(stderr,"CWD %s\n", cwd_buffer);
     */
     /* No one seems to want GlobalDir to default to abspath(CWD).  I'm leaving
-       the code here in case you do. MJT */ 
+       the code here in case you do. MJT */
     strcpy(cwd_buffer, ".");
     MetaData.GlobalDir = cwd_buffer;
     if (MyProcessorNumber == ROOT_PROCESSOR)
@@ -2196,13 +2054,13 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     MetaData.SimulationUUID = new char[MAX_LINE_LENGTH];
     get_uuid(MetaData.SimulationUUID);
   }
- 
+
    for (int i=0; i<MetaData.TopGridRank;i++)
     TopGridDx[i]=(DomainRightEdge[i]-DomainLeftEdge[i])/MetaData.TopGridDims[i];
 
  //  for (int i=0; i<MetaData.TopGridRank; i++)
-//      fprintf (stderr, "read  %"ISYM"  %"ISYM" \n", 
-// 	      MetaData.LeftFaceBoundaryCondition[i], 
+//      fprintf (stderr, "read  %"ISYM"  %"ISYM" \n",
+// 	      MetaData.LeftFaceBoundaryCondition[i],
 // 	      MetaData.RightFaceBoundaryCondition[i]);
 
   if (UseCUDA) {
@@ -2239,8 +2097,8 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     }
   } // if(StarMakerMinimumMassRamp > 0)
 
-  
-  
+
+
   return SUCCESS;
 
 }

--- a/src/enzo/ReadParameterFile.C
+++ b/src/enzo/ReadParameterFile.C
@@ -81,14 +81,12 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
   active_particle_types = new char*[MAX_ACTIVE_PARTICLE_TYPES];
   int active_particles = 0;
 
-#ifdef USE_GRACKLE
   /* Check if use_grackle is True and copy over default parameters to
      their Enzo equivalents */
   if (GrackleSetDefaultParameters(fptr) == FAIL){
     ENZO_FAIL("Error in GrackleSetDefaultParameters.\n");
   }
   rewind(fptr);
-#endif // USE_GRACKLE
 
   /* read until out of lines */
 
@@ -1723,7 +1721,6 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
   }
 
 
-#ifdef USE_GRACKLE
 
   // Check if Grackle is being used, and read in parameters if so
   if (GrackleReadParameters(fptr, MetaData.Time) == FAIL){
@@ -1733,7 +1730,6 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
   if (use_grackle == FALSE) {
     /* If Grackle is not being used, handle other possible cooling / chemistry settings  */
-#endif // USE_GRACKLE
 
     /* If GadgetEquilibriumCooling == TRUE, we don't want MultiSpecies
     or RadiationFieldType to be on - both are taken care of in
@@ -1788,9 +1784,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 	ENZO_FAIL("Error in InitializeRadiationFieldData.");
       }
 
-#ifdef USE_GRACKLE
   } // else (if Grackle == False )
-#endif
 
   /* If using MBHFeedback = 2 to 5 (Star->FeedbackFlag = MBH_JETS),
      you need MBHParticleIO for angular momentum */

--- a/src/enzo/SetDefaultGlobalValues.C
+++ b/src/enzo/SetDefaultGlobalValues.C
@@ -538,36 +538,6 @@ int SetDefaultGlobalValues(TopGridData &MetaData)
   CloudyCoolingData.CloudyElectronFractionFactor = 9.153959e-3; // calculated using Cloudy 07.02 abundances
 
   use_grackle = FALSE;
-#ifdef USE_GRACKLE
-    // Grackle chemistry data structure.
-  chemistry_data *my_chemistry;
-  my_chemistry = new chemistry_data;
-  if (set_default_chemistry_parameters(my_chemistry) == FAIL) {
-    ENZO_FAIL("Error in grackle: set_default_chemistry_parameters\n");
-  }
-
-  // Map Grackle defaults to corresponding Enzo parameters
-  Gamma                                 = (float) grackle_data->Gamma;
-  MultiSpecies                          = (int) grackle_data->primordial_chemistry;
-  MetalCooling                          = (int) grackle_data->metal_cooling;
-  H2FormationOnDust                     = (int) grackle_data->h2_on_dust;
-  CloudyCoolingData.CMBTemperatureFloor = (int) grackle_data->cmb_temperature_floor;
-  ThreeBodyRate                         = (int) grackle_data->three_body_rate;
-  CIECooling                            = (int) grackle_data->cie_cooling;
-  H2OpticalDepthApproximation           = (int) grackle_data->h2_optical_depth_approximation;
-  PhotoelectricHeating                  = (int) grackle_data->photoelectric_heating;
-  PhotoelectricHeatingRate              = (float) grackle_data->photoelectric_heating_rate;
-  CoolData.NumberOfTemperatureBins      = (int) grackle_data->NumberOfTemperatureBins;
-  RateData.CaseBRecombination           = (int) grackle_data->CaseBRecombination;
-  CoolData.TemperatureStart             = (float) grackle_data->TemperatureStart;
-  CoolData.TemperatureEnd               = (float) grackle_data->TemperatureEnd;
-  RateData.NumberOfDustTemperatureBins  = (int) grackle_data->NumberOfDustTemperatureBins;
-  RateData.DustTemperatureStart         = (float) grackle_data->DustTemperatureStart;
-  RateData.DustTemperatureEnd           = (float) grackle_data->DustTemperatureEnd;
-  CoolData.HydrogenFractionByMass       = (float) grackle_data->HydrogenFractionByMass;
-  CoolData.DeuteriumToHydrogenRatio     = (float) grackle_data->DeuteriumToHydrogenRatio;
-  CoolData.SolarMetalFractionByMass     = (float) grackle_data->SolarMetalFractionByMass;
-#endif
 
   OutputCoolingTime = FALSE;
   OutputTemperature = FALSE;

--- a/src/enzo/WriteParameterFile.C
+++ b/src/enzo/WriteParameterFile.C
@@ -535,18 +535,21 @@ int WriteParameterFile(FILE *fptr, TopGridData &MetaData, char *name = NULL)
   fprintf(fptr, "SGScoeffNLb                    = %"FSYM"\n", SGScoeffNLb);
   fprintf(fptr, "use_grackle                 = %"ISYM"\n", use_grackle);
 #ifdef USE_GRACKLE
-  /* Grackle chemistry parameters */
-  fprintf(fptr, "with_radiative_cooling      = %d\n", grackle_data->with_radiative_cooling);
-  fprintf(fptr, "use_volumetric_heating_rate = %d\n", grackle_data->use_volumetric_heating_rate);
-  fprintf(fptr, "use_specific_heating_rate   = %d\n", grackle_data->use_specific_heating_rate);
-  fprintf(fptr, "self_shielding_method       = %d\n", grackle_data->self_shielding_method);
-  fprintf(fptr, "H2_self_shielding           = %d\n", grackle_data->H2_self_shielding);
-  fprintf(fptr, "grackle_data_file           = %s\n", grackle_data->grackle_data_file);
-  fprintf(fptr, "UVbackground                = %d\n", grackle_data->UVbackground);
-  fprintf(fptr, "Compton_xray_heating        = %d\n", grackle_data->Compton_xray_heating);
-  fprintf(fptr, "LWbackground_intensity      = %lf\n", grackle_data->LWbackground_intensity);
-  fprintf(fptr, "LWbackground_sawtooth_suppression = %d\n", grackle_data->LWbackground_sawtooth_suppression);
-  /********************************/
+
+  if (grackle_data->use_grackle){
+    /* Grackle chemistry parameters */
+    fprintf(fptr, "with_radiative_cooling      = %d\n", grackle_data->with_radiative_cooling);
+    fprintf(fptr, "use_volumetric_heating_rate = %d\n", grackle_data->use_volumetric_heating_rate);
+    fprintf(fptr, "use_specific_heating_rate   = %d\n", grackle_data->use_specific_heating_rate);
+    fprintf(fptr, "self_shielding_method       = %d\n", grackle_data->self_shielding_method);
+    fprintf(fptr, "H2_self_shielding           = %d\n", grackle_data->H2_self_shielding);
+    fprintf(fptr, "grackle_data_file           = %s\n", grackle_data->grackle_data_file);
+    fprintf(fptr, "UVbackground                = %d\n", grackle_data->UVbackground);
+    fprintf(fptr, "Compton_xray_heating        = %d\n", grackle_data->Compton_xray_heating);
+    fprintf(fptr, "LWbackground_intensity      = %lf\n", grackle_data->LWbackground_intensity);
+    fprintf(fptr, "LWbackground_sawtooth_suppression = %d\n", grackle_data->LWbackground_sawtooth_suppression);
+    /********************************/
+  }
 #endif
   fprintf(fptr, "RadiativeCooling               = %"ISYM"\n", RadiativeCooling);
   fprintf(fptr, "RadiativeCoolingModel          = %"ISYM"\n", RadiativeCoolingModel);

--- a/src/enzo/pop3_maker.F
+++ b/src/enzo/pop3_maker.F
@@ -172,7 +172,7 @@ c
                bmass = d(i,j,k) * m1
 c               isosndsp2 = sndspdC * temp(i,j,k)
 c               jeanmass = pi_val/(6._RKIND*sqrt(d(i,j,k)*dble(d1))) *
-c     &                    dble(pi_val * isosndsp2 / GravConst**1.5_RKIND / SolarMass
+c     &                    dble(pi_val * isosndsp2 / GravConst)**1.5_RKIND / SolarMass
 c
 c               if (bmass .lt. jeanmass) 
 c     &            write(40,*) '2',bmass,jeanmass

--- a/src/enzo/typedefs.h
+++ b/src/enzo/typedefs.h
@@ -192,8 +192,8 @@ enum field_type {Density, TotalEnergy, InternalEnergy, Pressure,
                  FieldUndefined};
 */
 
-#define FieldTypeIsDensity(A) ((((A) >= TotalEnergy && (A) <= Velocity3) || ((A) >= kphHI && (A) <= kdissH2I) || ((A) >= RadiationFreq0 && (A) <= RaySegments) || ((A) >= Bfield1 && (A) <= AccelerationField3)) ? FALSE : TRUE)
-#define FieldTypeIsRadiation(A) ((((A) >= kphHI && (A) <= kdissH2I) || ((A) >= RadiationFreq0 && (A) <= RadiationFreq9)) ? TRUE : FALSE)
+#define FieldTypeIsDensity(A) ((((A) >= TotalEnergy && (A) <= Velocity3) || ((A) >= kphHI && (A) <= kdissH2I) || ((A) == kdissH2II) || ((A) == kphHM) || ((A) >= RadiationFreq0 && (A) <= RaySegments) || ((A) >= Bfield1 && (A) <= AccelerationField3)) ? FALSE : TRUE)
+#define FieldTypeIsRadiation(A) ((((A) >= kphHI && (A) <= kdissH2I) || ((A) == kdissH2II) || ((A) == kphHM) || ((A) >= RadiationFreq0 && (A) <= RadiationFreq9)) ? TRUE : FALSE)
 #define FieldTypeNoInterpolate(A) (((((A) >= Mach) && ((A) <= PreShockDensity)) || ((A) == GravPotential) || ((A) == RaySegments)) ? TRUE : FALSE)
 
 /* Different stochastic forcing types */


### PR DESCRIPTION
Fixes bugfix in mapping Grackle's default parameters to the equivalent Enzo parameters when Grackle is compiled but not in use. This now only occurs when Grackle is actually in use.

I threw this together quickly and just tested that this fixes the crashes that happened in  PhotonTestAMR. So worth a look.

(This PR includes a couple very minor (but fully unrelated) commits from another currently open but accepted PR)