### PR TITLE
Bugfix for ActiveParticleFinalize function call

### DIFF
--- a/src/enzo/EvolveLevel.C
+++ b/src/enzo/EvolveLevel.C
@@ -742,12 +742,12 @@ int EvolveLevel(TopGridData *MetaData, LevelHierarchyEntry *LevelArray[],
  
       if (UseMagneticSupernovaFeedback)
 	Grids[grid1]->GridData->MagneticSupernovaList.clear(); 
+    } //end loop over grids
 
+    /* Finalize (accretion, feedback etc) for Active particles. */
     ActiveParticleFinalize(Grids, MetaData, NumberOfGrids, LevelArray,
                            level, NumberOfNewActiveParticles);
-    } //end loop over grids
     /* Finalize (accretion, feedback, etc.) star particles */
-
     StarParticleFinalize(Grids, MetaData, NumberOfGrids, LevelArray,
 			 level, AllStars, TotalStarParticleCountPrevious, OutputNow);
 


### PR DESCRIPTION
ActiveParticleFinalize function removed from the loop over grids.  Active particle counting over all grids and processors is already done 
inside CommunicationUpdateActiveParticleCount function which is getting called in ActiveParticleFinalize function. So, no need to loop over grids again.