### PR TITLE
Add weekly tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,3 +251,17 @@ workflows:
        - test-compile-options
        - test-suite
        - docs-build
+
+   weekly:
+     triggers:
+       - schedule:
+           cron: "0 0 * * 1"
+           filters:
+            branches:
+              only:
+                - master
+
+     jobs:
+       - test-compile-options
+       - test-suite
+       - docs-build


### PR DESCRIPTION
This configures circleci to run the test suite once a week (Monday at midnight). This should make it easier to catch issues that crop up because of changes in dependencies, like Grackle.