### PR TITLE
Minor changes for StochasticForcing

### DIFF
--- a/doc/manual/source/parameters/index.rst
+++ b/doc/manual/source/parameters/index.rst
@@ -5020,7 +5020,7 @@ Turbulence Simulation with Stochastic Forcing (59)
 
 
 ``DrivenFlowProfile`` (external)
-    Shape of forcing power spectrum (1: delta peak, 2: band, 3: parabolic window).
+    Shape of forcing power spectrum (1: delta peak, 2: parabolic window, 3: band).
 
 ``DrivenFlowAlpha`` (external)
     Ratio of domain length to integral length for each dimension (L = X/alpha).

--- a/src/enzo/StochasticForcing_Init.C
+++ b/src/enzo/StochasticForcing_Init.C
@@ -17,8 +17,8 @@
 /           Parameters:
 /           my_spectral_rank -- dimension of Fouries space = grid rank
 /           my_spect_profile -- shape of forcing power spectrum
-/                               (1: delta peak, 2: band, 
-/                                3: parabolic window) 
+/                               (1: delta peak, 2: parabolic, 
+/                                3: band) 
 /           my_alpha -- ratio of domain length to integral length
 /                       for each dimension (L = X/alpha)
 /           my_band_width -- determines band width of the forcing 

--- a/src/enzo/StochasticForcing_Init.C
+++ b/src/enzo/StochasticForcing_Init.C
@@ -180,6 +180,7 @@ AutoCorrlTime[0],AutoCorrlTime[1],AutoCorrlTime[2]);
 		    Amplitude[0][i-1] *= Amplitude[0][i-1];
 		} else if (SpectProfile == Band) {
 		    if ((x1 >= 0.0) && (x2 >= 0.0)) Amplitude[0][i-1] = 1.0;
+            else Amplitude[0][i-1] = 0.0;
 		}
 		if (debug) {
 		    printf("i = %"ISYM", a = %"FSYM"\n",i,a);
@@ -229,6 +230,7 @@ AutoCorrlTime[0],AutoCorrlTime[1],AutoCorrlTime[2]);
 			    Amplitude[0][n] *= Amplitude[0][n];
 			} else if (SpectProfile == Band) {
 			    if ((x1 >= 0.0) && (x2 >= 0.0)) Amplitude[0][n] = 1.0;
+                else Amplitude[0][n] = 0.0;
 			}
             
 			if (debug) {
@@ -279,6 +281,7 @@ AutoCorrlTime[0],AutoCorrlTime[1],AutoCorrlTime[2]);
 				    Amplitude[0][n] *= Amplitude[0][n];
 				} else if (SpectProfile == Band) {
 				    if ((x1 >= 0.0) && (x2 >= 0.0)) Amplitude[0][n] = 1.0;
+                    else Amplitude[0][n] = 0.0;
 				}
                 
 				if (debug) {


### PR DESCRIPTION
This commit fixes two issues my collaborators and I have encountered when using the StochasticForcing problem:

1) The docs have an error for the DrivenFlowProfile parameter, in which the value for 'band' and 'parabolic window' are switched. This conflicts with correct statements in the comments of the .enzo file  run/MHD/3D/StochasticForcing/StochasticForcing.enzo and the definitions in typedefs.h from lines 201-204.

2) For certain sets of compilers, some amplitudes of the driving field are incorrectly non-zero, because they are never explicitly set in the code. Here I just add some else statements that guarantee these amplitudes are zero when they should be in the Band case.