### PR TITLE
Bugfix: must-refine particles identification by mass

### DIFF
--- a/src/enzo/GrackleReadParameters.C
+++ b/src/enzo/GrackleReadParameters.C
@@ -218,7 +218,8 @@ int GrackleReadParameters(FILE *fptr, FLOAT InitTime)
   code_units grackle_units;
   grackle_units.a_units = 1.0;
   float DensityUnits = 1.0, LengthUnits = 1.0, TemperatureUnits = 1.0,
-    TimeUnits = 1.0, VelocityUnits = 1.0, MassUnits = 1.0;
+    TimeUnits = 1.0, VelocityUnits = 1.0;
+  double MassUnits = 1.0;
   if (GetUnits(&DensityUnits, &LengthUnits, &TemperatureUnits,
                &TimeUnits, &VelocityUnits, &MassUnits, InitTime) == FAIL) {
     ENZO_FAIL("Error in GetUnits.\n");


### PR DESCRIPTION
**Star objects:** The recent change in #120 was missing a line that first checks whether there are any local star objects before copying them to a comm buffer.

**Must-refine:** Allow for some machine-precision epsilon when comparing particle masses to determine which initial nested level they came from. Also related, the `f` suffixes in the EPSILON defines caused them to be 32-bit floats instead of 64- or 128-bit.