### PR TITLE
Adding a page with sample parameter files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,6 @@ src/enzo/Make.mach.mymac
 src/P-GroupFinder/P-GroupFinder
 
 doc/manual/build
+doc/manual/source/_build
 
 run/results.js

--- a/doc/manual/Makefile
+++ b/doc/manual/Makefile
@@ -34,7 +34,7 @@ help:
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
 clean:
-	-rm -rf $(BUILDDIR)/*
+	-rm -rf $(BUILDDIR)/* source/_build/
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/doc/manual/source/user_guide/RunTestProblem.rst
+++ b/doc/manual/source/user_guide/RunTestProblem.rst
@@ -129,42 +129,10 @@ directory. They are kept in input:
 ::
 
     > ls input/
-    ATOMIC.DAT  cool_rates.in  lookup_metal0.3.data
+    ATOMIC.DAT           cosmic_ray.dat                 LW_J21.in              metal_cooling.pro       resubmit.sh
+    cooling.pro          enzo_parameter_conflicts.txt   make_Zcool_table.pro   metal_cool_pop3.dat     TREECOOL
+    cool_rates.in        hm12_photorates.dat            metal_cool.dat         metal_cool_ratios.dat   zcool_sd93.dat
+    cool_rates.in_300K   lookup_metal0.3.data          'metal_cool.dat_z=15'   restart.sh
 
 You can either copy the files into your run directory as a matter
 of habit, or copy them only if they're needed.
-
-Outputs
--------
-
-
--  ` AMRCollapseTest.tar.gz <http://lca.ucsd.edu/software/enzo/data/AMRCollapseTest.tar.gz>`_
-   - 24 MB
--  ` AMRShockPool2D.tar.gz <http://lca.ucsd.edu/software/enzo/data/AMRShockPool2D.tar.gz>`_
-   - 35 KB
--  ` AMRShockTube.tar.gz <http://lca.ucsd.edu/software/enzo/data/AMRShockTube.tar.gz>`_
-   - 23 KB
--  ` AMRZeldovichPancake.tar.gz <http://lca.ucsd.edu/software/enzo/data/AMRZeldovichPancake.tar.gz>`_
-   - 72 KB
--  ` AdiabaticExpansion.tar.gz <http://lca.ucsd.edu/software/enzo/data/AdiabaticExpansion.tar.gz>`_
-   - 31 KB
--  ` CollapseTest.tar.gz <http://lca.ucsd.edu/software/enzo/data/CollapseTest.tar.gz>`_
-   - 5.4 MB
--  ` CollideTest.tar.gz <http://lca.ucsd.edu/software/enzo/data/CollideTest.tar.gz>`_
-   - 7.6 MB
--  ` DoubleMachReflection.tar.gz <http://lca.ucsd.edu/software/enzo/data/DoubleMachReflection.tar.gz>`_
-   - 2.1 MB
--  ` ExtremeAdvectionTest.tar.gz <http://lca.ucsd.edu/software/enzo/data/ExtremeAdvectionTest.tar.gz>`_
-   - 430 KB
--  ` GravityStripTest.tar.gz <http://lca.ucsd.edu/software/enzo/data/GravityStripTest.tar.gz>`_
-   - 12 MB
--  ` GravityTest.tar.gz <http://lca.ucsd.edu/software/enzo/data/GravityTest.tar.gz>`_
-   - 99 KB
--  ` GravityTestSphere.tar.gz <http://lca.ucsd.edu/software/enzo/data/GravityTestSphere.tar.gz>`_
-   - 4.6 MB
--  ` Implosion.tar.gz <http://lca.ucsd.edu/software/enzo/data/Implosion.tar.gz>`_
-   - 5.6 MB
--  ` ImplosionAMR.tar.gz <http://lca.ucsd.edu/software/enzo/data/ImplosionAMR.tar.gz>`_
-   - 3.5 MB
-
-

--- a/doc/manual/source/user_guide/SampleParameterFiles.rst
+++ b/doc/manual/source/user_guide/SampleParameterFiles.rst
@@ -1,0 +1,82 @@
+Sample Parameter Files from Publications
+========================================
+
+Here is a collection of parameter files that are equivalent or similar to ones
+used in publications.  Each example has a description and motivation behind the choice of
+important parameters.
+
+Wise et al. (2014)
+------------------
+(`Publication link
+<https://ui.adsabs.harvard.edu/abs/2014MNRAS.442.2560W/abstract>`_)
+(:download:`Parameter file <./samples/wise2014_zoomin_update.enzo>`)
+(:download:`MUSIC parameter file <./samples/SG64-L2.conf>`)
+(`Lagrangian data file <https://www.dropbox.com/s/x53m3a1566vhotq/SG64-L2-Lagrangian.dat.gz?dl=1>`_ 622kB)
+
+This parameter file will set up a simulation **similar** to the paper's
+simulation.  Some parameter choices are updated to be consistent with papers
+written after the original simulation was run in 2012. It models Pop III star
+formation and the transition to galaxy formation.  While the production
+simulation was a 256\ :sup:`3` AMR everywhere simulation, this sample file is a
+zoom-in calculation (the user needs to generate the ICs with
+:ref:`MUSIC <CosmologicalInitialConditions>`) focused on a
+single 10\ :sup:`8` solar mass halo at z = 10.
+
+Hierarchy setup
+^^^^^^^^^^^^^^^
+1 Mpc comoving box with a 64\ :sup:`3` root grid resolution and 2 nested grids
+
+* ``MaximumRefinementLevel = 14``: maximal comoving resolution of ~1 pc
+* ``MaximumParticleRefinementLevel = 11``: to remove the discreteness of DM particles, smooth them over ~1 proper pc below which baryons become dominant
+* ``CellFlaggingMethod = 2 4 6 8``: Refine by baryon/DM mass, Jeans length, and must-refine cosmological particles
+* ``RefineByJeansLengthSafetyFactor = 8``: Resolve the local Jeans length by at least 8 cells
+* ``MustRefineParticlesCreateParticles = 3``: Use a :ref:`dynamical nested region <MRPNestedGrid>` that's specified by the particle types given by MUSIC
+* ``MustRefineParticlesRefineToLevel = 2``: Refine the innermost region to at least level 2
+
+Hydrodynamics
+^^^^^^^^^^^^^
+* ``RiemannSolver = 4``: use the HLLC solver for more stability in supernova blastwaves
+* ``RiemannSolverFallback = 1``: use the HLL solver when HLLC fails
+
+Cooling and chemistry
+^^^^^^^^^^^^^^^^^^^^^
+* ``MultiSpecies = 3``: 12-species primordial radiative cooling
+* ``MetalCooling = 1``: tabulated metal cooling
+* ``grackle_data_file = cloudy_metals_2008_3D-lwb.h5``: metal cooling with a Lyman-Werner (LW) background from `Qin+ (2020) <https://arxiv.org/abs/2003.04442>`_
+* ``UVbackground = 1``: Use the LW background the table above
+* ``H2_self_shielding = 1``: `Wolcott-Green et al. (2011) <https://ui.adsabs.harvard.edu/abs/2011MNRAS.418..838W/abstract>`_ model
+
+Star formation and feedback
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Metal-free and metal-enriched star formation with radiative and supernova
+feedback
+
+* ``StarParticleCreation = 40``: Use model #3 (Pop III stars) and #5 (radiating star clusters)
+* ``StarParticleFeedback = 40``: Use model #3 and #5
+
+Pop III particles
+"""""""""""""""""
+* ``PopIIIOverDensityThreshold = -1e6``: The negative indicates units in particles per cm\ :sup:`3`. This number density is consistent with Pop III formation at the resolution level of 0.1 proper pc.
+* ``PopIIIH2CriticalFraction = 1e-3``: This is an appropriate H\ :sub:`2` fraction at the above density threshold
+* ``PopIIIMetalCriticalFraction = 1.295e-6``: Use a critical transition metallicity of 10\ :sup:`-4` of solar
+* ``PopIIIUseHypernova = 0``: Use a typical 10\ :sup:`51` erg core-collapse supernova energy for stars between 11 and 40 solar masses
+* ``PopIIIInitialMassFunction = 1``: Use a Pop III IMF defined in Wise et al. (2014)
+* ``PopIIIStarMass = 20``: Use a characteristic mass of 20 solar masses in the above IMF. Motivated by `Hirano et al. (2015) <https://ui.adsabs.harvard.edu/abs/2015MNRAS.448..568H/abstract>`_ and `Susa (2019) <https://ui.adsabs.harvard.edu/abs/2019ApJ...877...99S/abstract>`_
+
+Star cluster particles
+""""""""""""""""""""""
+* ``StarClusterMinDynamicalTime = 3e+06``: Motivated by `Tan et al. (2006) <https://ui.adsabs.harvard.edu/abs/2006ApJ...641L.121T/abstract>`_ who found that molecular clouds have dynamical times around 700 kyr and form stars over several dynamical times. There could be newer references.
+* ``StarClusterIonizingLuminosity = 1.9e+46``: Use the average over 20 Myr from the metal-poor binary model of `Rosdahl et al. (2018) <https://ui.adsabs.harvard.edu/abs/2018MNRAS.479..994R/abstract>`_
+* ``StarClusterSNEnergy = 1e49``: Calculated from a Salpeter IMF, i.e. 1 SN per 100 solar masses of stars
+* ``StarClusterFormEfficiency = 0.07``: Motivated by `Krumholz et al. (2007) <https://ui.adsabs.harvard.edu/abs/2005ApJ...630..250K/abstract>`_. This converts 7% of the cold gas within the star forming cloud into stars. There could be newer references.
+* ``StarClusterMinimumMass = 1000``: (in solar masses) equivalent to the smallest observed star clusters
+
+Radiative transfer
+^^^^^^^^^^^^^^^^^^
+Uses the adaptive ray tracing machinery that is sourced by both types of star
+particles
+
+* ``RadiativeTransferOpticallyThinH2 = 1``: Source a (1/r\ :sup:`2`) LW radiation field from the star particles.  Important for star formation regulation
+* ``RadiativeTransferRadiationPressure = 1``: Consider momentum transfer between the ionizing photons and absorbing gas. Plays a role at small distances in dense gas and high flux
+* ``RadiativeTransferSourceClustering = 1``: Use ray merging to conserve memory (and maybe speed it up)
+* ``RadiativeTransferPhotonMergeRadius = 3.0``: Merge rays at 3 times the separation between sources that are paired in a tree

--- a/doc/manual/source/user_guide/index.rst
+++ b/doc/manual/source/user_guide/index.rst
@@ -58,4 +58,4 @@ inquiries and comments should be directed to the `Enzo Users' List
    CosmologicalInitialConditions.rst
    RunningLargeSimulations.rst
    EnzoOutputFormat.rst
-
+   SampleParameterFiles.rst

--- a/doc/manual/source/user_guide/samples/SG64-L2.conf
+++ b/doc/manual/source/user_guide/samples/SG64-L2.conf
@@ -1,0 +1,45 @@
+[setup]
+boxlength = 0.6766
+zstart = 249
+levelmin = 6
+levelmin_TF = 6
+levelmax = 8
+padding = 2
+overlap = 0
+align_top = yes
+baryons = yes
+use_2LPT = yes
+use_LLA = no
+periodic_TF = yes
+region = convex_hull
+region_point_file = SG64-L2-Lagrangian.dat
+region_point_shift = -29, -5, 21
+region_point_levelmin = 6
+
+[cosmology]
+Omega_m = 0.3111   # Planck 2018
+Omega_L = 0.6889
+Omega_b = 0.0489747
+H0 = 67.66
+sigma_8 = 0.8102
+nspec = 0.9665
+transfer = eisenstein
+
+[random]
+seed[6] = 202004290
+seed[7] = 302004290
+seed[8] = 402004290
+seed[9] = 502004290
+
+[output]
+format = enzo
+filename = SG64-L2
+
+[poisson]
+accuracy = 1e-5
+pre_smooth = 3
+post_smooth = 3
+smoother = gs
+laplace_order = 6
+grad_order = 6
+

--- a/doc/manual/source/user_guide/samples/wise2014_zoomin_update.enzo
+++ b/doc/manual/source/user_guide/samples/wise2014_zoomin_update.enzo
@@ -1,0 +1,181 @@
+# AMR PROBLEM DEFINITION FILE: Cosmology Simulation (amr version)
+#
+#  define problem
+#
+ProblemType                = 30      // cosmology simulation
+TopGridRank                = 3
+TopGridDimensions          = 64 64 64
+PotentialIterations        = 10
+SelfGravity                = 1       // gravity on
+TopGridGravityBoundary     = 0       // Periodic BC for gravity
+LeftFaceBoundaryCondition  = 3 3 3   // same for fluid
+RightFaceBoundaryCondition = 3 3 3
+#
+#  problem parameters
+#
+CosmologySimulationOmegaBaryonNow       = 0.0489747
+CosmologySimulationOmegaCDMNow          = 0.262125
+#CosmologySimulationInitialTemperature   = 300
+CosmologySimulationDensityName          = GridDensity
+CosmologySimulationVelocity1Name        = GridVelocities_x
+CosmologySimulationVelocity2Name        = GridVelocities_y
+CosmologySimulationVelocity3Name        = GridVelocities_z
+CosmologySimulationParticleVelocity1Name = ParticleVelocities_x
+CosmologySimulationParticleVelocity2Name = ParticleVelocities_y
+CosmologySimulationParticleVelocity3Name = ParticleVelocities_z
+CosmologySimulationParticleDisplacement1Name = ParticleDisplacements_x
+CosmologySimulationParticleDisplacement2Name = ParticleDisplacements_y
+CosmologySimulationParticleDisplacement3Name = ParticleDisplacements_z
+CosmologySimulationCalculatePositions   = 1
+CosmologySimulationNumberOfInitialGrids  = 3
+CosmologySimulationGridDimension[1]      =               42               50               42
+CosmologySimulationGridLeftEdge[1]       =         0.359375         0.328125         0.328125
+CosmologySimulationGridRightEdge[1]      =           0.6875          0.71875          0.65625
+CosmologySimulationGridLevel[1]          = 1
+CosmologySimulationGridDimension[2]      =               72               88               72
+CosmologySimulationGridLeftEdge[2]       =            0.375          0.34375          0.34375
+CosmologySimulationGridRightEdge[2]      =          0.65625           0.6875            0.625
+CosmologySimulationGridLevel[2]          = 2
+
+#
+# must-refine particle parameters
+#
+CosmologySimulationParticleTypeName     = RefinementMask
+MustRefineParticlesCreateParticles = 3
+MustRefineParticlesRefineToLevel   = 2
+
+#
+#  define cosmology parameters
+#
+ComovingCoordinates        = 1       // Expansion ON
+CosmologyOmegaMatterNow    = 0.3111
+CosmologyOmegaDarkMatterNow= 0.262125
+CosmologyOmegaLambdaNow    = 0.6889
+CosmologyHubbleConstantNow = 0.6766    // in km/s/Mpc
+CosmologyComovingBoxSize   = 0.6766     // in Mpc/h = 100 Mpc comoving
+CosmologyMaxExpansionRate  = 0.015   // maximum allowed delta(a)/a
+CosmologyInitialRedshift   = 249.000000
+CosmologyFinalRedshift 	   = 10.000000
+GravitationalConstant      = 1       // this must be true for cosmology
+#
+#  set I/O and stop/start parameters
+#
+StopCycle			= 100000          // stop after this many cycles
+#CycleSkipDataDump		= 10          // output every N cycles
+DataDumpName			= output_
+dtDataDump			= 0.877142
+StopCPUTime			= 420000  // seconds
+HierarchyFileOutputFormat	= 1
+ParallelRootGridIO		= 1
+
+#
+#  set hydro parameters
+#
+Gamma				= 1.6667
+PPMDiffusionParameter		= 0       // diffusion off
+DualEnergyFormalism		= 1       // use total & internal energy
+InterpolationMethod		= 1       // SecondOrderA
+FluxCorrection			= 2       // includes species correction
+RiemannSolver			= 4       // HLLC
+RiemannSolverFallback		= 1       // use HLL after failure
+ConservativeInterpolation	= 0
+CourantSafetyNumber		= 0.3
+ParticleCourantSafetyNumber	= 0.8
+CorrectParentBoundaryFlux       = 1
+
+#
+#  set cooling/heating parameters
+#
+use_grackle                 = 1
+with_radiative_cooling      = 1
+MultiSpecies                = 3  // 12-species
+MetalCooling                = 1  // used by grackle only (ignore as an Enzo parameter)
+
+// includes Lyman-Werner BG from Qin+2020
+grackle_data_file           = cloudy_metals_2008_3D-lwb.h5
+UVbackground                = 1
+H2_self_shielding           = 1  // Wolcott-Green+2011
+ThreeBodyRate               = 5  // Forrey 2013
+
+#
+#  set grid refinement parameters
+#
+StaticHierarchy			= 0	       // dynamic hierarchy
+MaximumRefinementLevel		= 14
+MaximumGravityRefinementLevel 	= 14
+MaximumParticleRefinementLevel 	= 11           // 0.7 pc at z=10
+RefineBy			= 2	       // refinement factor
+CellFlaggingMethod		= 2 4 6 8      // use gas/DM mass, Jeans, MRP for refinement 
+UseMinimumPressureSupport	= 0
+RefineByJeansLengthSafetyFactor = 8.0
+UnigridTranspose		= 2
+PartitionNestedGrids		= 1
+MinimumEfficiency		= 0.3  // fraction efficiency (flagged/total cells in a grid)
+
+// 2.5 times the initial density refers to level-0: divide by 8 for each additional level
+MinimumOverDensityForRefinement		= 0.0390625 0.0390625
+MinimumMassForRefinementLevelExponent	= -0.2 0.0
+#
+#  set some global parameters
+#
+GreensFunctionMaxNumber   = 30   // # of greens function at any one time
+
+#
+# Star formation and feedback
+#
+StarParticleCreation   = 40   // star particle creation turned on, using model #5 and #3
+StarParticleFeedback   = 40   // stellar feedback turned on, using model #5 #3 ray tracing
+ 
+RadiativeTransfer			= 1
+RadiativeTransferRaysPerCell            = 5.1
+RadiativeTransferInitialHEALPixLevel    = 1
+RadiativeTransferHydrogenOnly           = 0
+RadiativeTransferOpticallyThinH2        = 1
+RadiativeTransferPeriodicBoundary       = 0
+RadiativeTransferAdaptiveTimestep       = 1
+RadiativeTransferRadiationPressure      = 1
+RadiativeTransferHubbleTimeFraction     = 10
+RadiativeTransferPhotonMergeRadius      = 3.0
+RadiativeTransferSourceClustering       = 1
+
+#
+#  set radiation background (unused)
+#  (because they're set in Grackle)
+#
+
+#RadiationFieldType   = 14  # Wise+ (2012) LWB
+#RadiationFieldType    = 9  # LWB (either constant or tabulated)
+#TabulatedLWBackground = 0  # Uses LW_J21.in (z & JLW in each line)
+
+# in flux (=4*pi*J_LW) used if TabulatedLWBackground == 0
+#RadiationSpectrumNormalization = 12.566e-21
+#RadiationShield                = 2  # H2 shielding only
+
+#
+#  Pop III/II parameters
+#
+ 
+PopIIIOverDensityThreshold            = -1e6  # negative means units in cm^-3
+PopIIIMetalCriticalFraction           = 1.295e-6 # 1e-4 Zsun
+PopIIIH2CriticalFraction              = 1e-3
+PopIIISupernovaRadius                 = 10    # pc
+PopIIISupernovaUseColour              = 1
+PopIIIHeliumIonization                = 1
+PopIIIUseHypernova                    = 0     # 1e51 erg CCSNe only
+
+PopIIIStarMass                        = 20
+PopIIIInitialMassFunction             = 1
+PopIIIInitialMassFunctionSeed         = 2020
+PopIIIMassRange                       = 1.000000 300.000000 
+
+StarClusterUseMetalField              = 1
+StarClusterMinDynamicalTime           = 3e+06  # years
+
+# (Rosdahl+ 2018; avg over 20 Myr; Z-poor binary model)
+StarClusterIonizingLuminosity         = 1.9e+46  # ph/s/Msun
+
+StarClusterSNEnergy                   = 1e49  # erg/Msun (1 CCSN per 100 Msun)
+StarClusterSNRadius                   = 10    # pc
+StarClusterFormEfficiency             = 0.07  # from Krumholz & McKee (2005) and Wise+ (2012)
+StarClusterMinimumMass                = 1000  # Msun
+StarClusterHeliumIonization           = 1


### PR DESCRIPTION
It's common for people to request/share parameter files from publications. @brittonsmith asked if I could make a shared Google doc for my simulations, and I thought it'd be best to add it to the Enzo documentation. I hope others think this is a good addition and will contribute their parameter files in the future!

The rendered html (without the theme) can be seen [here](https://www.dropbox.com/personal/temp?preview=SampleParameterFiles.html).