### PR TITLE
Memory leak fix - deleting radiation sources 

### DIFF
--- a/src/enzo/ActiveParticleInitialize.C
+++ b/src/enzo/ActiveParticleInitialize.C
@@ -30,6 +30,8 @@
 
 int FindTotalNumberOfParticles(LevelHierarchyEntry *LevelArray[]);
 
+RadiationSourceEntry* DeleteRadiationSource(RadiationSourceEntry *RS);
+
 int ActiveParticleInitialize(HierarchyEntry *Grids[], TopGridData *MetaData,
 			     int NumberOfGrids, LevelHierarchyEntry *LevelArray[], 
 			     int ThisLevel)
@@ -56,10 +58,13 @@ int ActiveParticleInitialize(HierarchyEntry *Grids[], TopGridData *MetaData,
   /* If radiation sources exist, delete them */
   if (RadiativeTransfer == TRUE) {
     RadiationSourceEntry *dummy;
-    while (GlobalRadiationSources != NULL) {
-      dummy = GlobalRadiationSources;
-      GlobalRadiationSources = GlobalRadiationSources->NextSource;
-      delete dummy;
+    if (GlobalRadiationSources!=NULL){
+      dummy = GlobalRadiationSources->NextSource;
+      while (dummy != NULL) {
+        dummy = DeleteRadiationSource(dummy);
+      }
+      delete GlobalRadiationSources;
+      GlobalRadiationSources = NULL;
     }
     GlobalRadiationSources = new RadiationSourceEntry;
     GlobalRadiationSources->NextSource = NULL;

--- a/src/enzo/ActiveParticleInitialize.C
+++ b/src/enzo/ActiveParticleInitialize.C
@@ -31,7 +31,7 @@
 int FindTotalNumberOfParticles(LevelHierarchyEntry *LevelArray[]);
 
 #ifdef TRANSFER
-RadiationSourceEntry* DeleteRadiationSource(RadiationSourceEntry *RS);
+void DeleteGlobalRadiationSources(void);
 #endif
 
 int ActiveParticleInitialize(HierarchyEntry *Grids[], TopGridData *MetaData,
@@ -59,15 +59,9 @@ int ActiveParticleInitialize(HierarchyEntry *Grids[], TopGridData *MetaData,
 #ifdef TRANSFER
   /* If radiation sources exist, delete them */
   if (RadiativeTransfer == TRUE) {
-    RadiationSourceEntry *dummy;
-    if (GlobalRadiationSources!=NULL){
-      dummy = GlobalRadiationSources->NextSource;
-      while (dummy != NULL) {
-        dummy = DeleteRadiationSource(dummy);
-      }
-      delete GlobalRadiationSources;
-      GlobalRadiationSources = NULL;
-    }
+
+    DeleteGlobalRadiationSources();
+
     GlobalRadiationSources = new RadiationSourceEntry;
     GlobalRadiationSources->NextSource = NULL;
     GlobalRadiationSources->PreviousSource = NULL;

--- a/src/enzo/ActiveParticleInitialize.C
+++ b/src/enzo/ActiveParticleInitialize.C
@@ -30,7 +30,9 @@
 
 int FindTotalNumberOfParticles(LevelHierarchyEntry *LevelArray[]);
 
+#ifdef TRANSFER
 RadiationSourceEntry* DeleteRadiationSource(RadiationSourceEntry *RS);
+#endif
 
 int ActiveParticleInitialize(HierarchyEntry *Grids[], TopGridData *MetaData,
 			     int NumberOfGrids, LevelHierarchyEntry *LevelArray[], 

--- a/src/enzo/DeleteRadiationSource.C
+++ b/src/enzo/DeleteRadiationSource.C
@@ -15,7 +15,9 @@
 #include <stdio.h>
 #include "ErrorExceptions.h"
 #include "macros_and_parameters.h"
+#include "typedefs.h"
 #include "RadiationSource.h"
+#include "global_data.h"
 
 RadiationSourceEntry* DeleteRadiationSource(RadiationSourceEntry *RS)
 {
@@ -49,4 +51,19 @@ RadiationSourceEntry* DeleteRadiationSource(RadiationSourceEntry *RS)
     delete RS;
   }
   return dummy;
+}
+
+void DeleteGlobalRadiationSources(void){
+
+  RadiationSourceEntry *dummy;
+  if (GlobalRadiationSources!=NULL){
+    dummy = GlobalRadiationSources->NextSource;
+    while (dummy != NULL) {
+      dummy = DeleteRadiationSource(dummy);
+    }
+    delete GlobalRadiationSources;
+    GlobalRadiationSources = NULL;
+  }
+
+  return;
 }

--- a/src/enzo/EvolvePhotons.C
+++ b/src/enzo/EvolvePhotons.C
@@ -214,6 +214,9 @@ int EvolvePhotons(TopGridData *MetaData, LevelHierarchyEntry *LevelArray[],
                        MAIN RADIATION TRANSPORT LOOP
    **********************************************************************/
 
+  int NumberOfSources = 0;
+  bool DeleteSources = FALSE;
+
   while (GridTime > PhotonTime) {
 
     /* Recalculate timestep if this isn't the first loop.  We already
@@ -236,8 +239,8 @@ int EvolvePhotons(TopGridData *MetaData, LevelHierarchyEntry *LevelArray[],
     RS = GlobalRadiationSources->NextSource;
     LastNode = RS_GridList;
     TempGridList = RS_GridList->NextGrid;
-    int NumberOfSources = 0;
-    bool DeleteSources = (FirstTime ||
+    NumberOfSources = 0;
+    DeleteSources = (FirstTime ||
 			  !(RadiativeTransferAdaptiveTimestep == FALSE &&
 			    RadiativeTransferSourceClustering == TRUE));
 			  
@@ -715,6 +718,28 @@ int EvolvePhotons(TopGridData *MetaData, LevelHierarchyEntry *LevelArray[],
     }
   }
 #endif
+
+  /* Double check and clean up photon sources that have expired */
+
+  if (NumberOfSources > 0){
+    RS = GlobalRadiationSources->NextSource;
+
+    /* Clean up photon sources if time is up */
+    while (RS != NULL){
+      if ( ((RS->CreationTime + RS->LifeTime) < PhotonTime) && LoopTime == TRUE &&
+	           DeleteSources) {
+      if (debug) {
+         fprintf(stdout, "\nEvolvePhotons: Deleted Source on lifetime limit \n");
+	       fprintf(stdout, "EvolvePhotons:  %"GSYM" %"GSYM" %"GSYM" \n",
+		             RS->CreationTime, RS->LifeTime, PhotonTime);
+      }
+	       RS = DeleteRadiationSource(RS);
+         NumberOfSources--;
+      }  else {
+        RS = RS->NextSource;
+      }
+    } // end while RS loop
+  } // end source clean up
 
   /* Delete GridList and Reset Grid IDs in static sources */
 

--- a/src/enzo/EvolvePhotons.C
+++ b/src/enzo/EvolvePhotons.C
@@ -727,17 +727,21 @@ int EvolvePhotons(TopGridData *MetaData, LevelHierarchyEntry *LevelArray[],
     /* Clean up photon sources if time is up */
     while (RS != NULL){
       if ( ((RS->CreationTime + RS->LifeTime) < PhotonTime) && LoopTime == TRUE &&
-	           DeleteSources) {
-      if (debug) {
-         fprintf(stdout, "\nEvolvePhotons: Deleted Source on lifetime limit \n");
-	       fprintf(stdout, "EvolvePhotons:  %"GSYM" %"GSYM" %"GSYM" \n",
-		             RS->CreationTime, RS->LifeTime, PhotonTime);
-      }
-	       RS = DeleteRadiationSource(RS);
-         NumberOfSources--;
+             DeleteSources) {
+
+        if (debug) {
+          fprintf(stdout, "\nEvolvePhotons: Deleted Source on lifetime limit \n");
+          fprintf(stdout, "EvolvePhotons:  %"GSYM" %"GSYM" %"GSYM" \n",
+                                             RS->CreationTime, RS->LifeTime, PhotonTime);
+        }
+
+        RS = DeleteRadiationSource(RS);
+        NumberOfSources--;
+
       }  else {
         RS = RS->NextSource;
       }
+
     } // end while RS loop
   } // end source clean up
 

--- a/src/enzo/StarParticleRadTransfer.C
+++ b/src/enzo/StarParticleRadTransfer.C
@@ -34,7 +34,7 @@ int GetUnits(float *DensityUnits, float *LengthUnits,
 	     float *TemperatureUnits, float *TimeUnits,
 	     float *VelocityUnits, FLOAT Time);
 
-RadiationSourceEntry* DeleteRadiationSource(RadiationSourceEntry *RS);
+void DeleteGlobalRadiationSources(void);
 
 int StarParticleRadTransfer(LevelHierarchyEntry *LevelArray[], int level,
 			    Star *AllStars)
@@ -52,15 +52,7 @@ int StarParticleRadTransfer(LevelHierarchyEntry *LevelArray[], int level,
 
   /* If sources exist, delete them */
 
-  RadiationSourceEntry *dummy;
-  if (GlobalRadiationSources!=NULL){
-    dummy = GlobalRadiationSources->NextSource;
-    while (dummy != NULL) {
-      dummy = DeleteRadiationSource(dummy);
-    }
-    delete GlobalRadiationSources;
-    GlobalRadiationSources = NULL;
-  }
+  DeleteGlobalRadiationSources();
 
   GlobalRadiationSources = new RadiationSourceEntry;
   GlobalRadiationSources->NextSource = NULL;

--- a/src/enzo/StarParticleRadTransfer.C
+++ b/src/enzo/StarParticleRadTransfer.C
@@ -58,6 +58,8 @@ int StarParticleRadTransfer(LevelHierarchyEntry *LevelArray[], int level,
     while (dummy != NULL) {
       dummy = DeleteRadiationSource(dummy);
     }
+    delete GlobalRadiationSources;
+    GlobalRadiationSources = NULL;
   }
 
   GlobalRadiationSources = new RadiationSourceEntry;

--- a/src/enzo/StarParticleRadTransfer.C
+++ b/src/enzo/StarParticleRadTransfer.C
@@ -34,6 +34,8 @@ int GetUnits(float *DensityUnits, float *LengthUnits,
 	     float *TemperatureUnits, float *TimeUnits,
 	     float *VelocityUnits, FLOAT Time);
 
+RadiationSourceEntry* DeleteRadiationSource(RadiationSourceEntry *RS);
+
 int StarParticleRadTransfer(LevelHierarchyEntry *LevelArray[], int level,
 			    Star *AllStars)
 {

--- a/src/enzo/StarParticleRadTransfer.C
+++ b/src/enzo/StarParticleRadTransfer.C
@@ -51,10 +51,11 @@ int StarParticleRadTransfer(LevelHierarchyEntry *LevelArray[], int level,
   /* If sources exist, delete them */
 
   RadiationSourceEntry *dummy;
-  while (GlobalRadiationSources != NULL) {
-    dummy = GlobalRadiationSources;
-    GlobalRadiationSources = GlobalRadiationSources->NextSource;
-    delete dummy;
+  if (GlobalRadiationSources!=NULL){
+    dummy = GlobalRadiationSources->NextSource;
+    while (dummy != NULL) {
+      dummy = DeleteRadiationSource(dummy);
+    }
   }
 
   GlobalRadiationSources = new RadiationSourceEntry;


### PR DESCRIPTION
Memory leak fix in radiation sources:

1) small fix in `EvolvePhotons`. Sources would sometimes (all of the time?) not get deleted properly in the main EvolvePhotons loop after the end of their life. Placing an additional check after the loop to see if there are any sources with lifetimes < PhotonTime. This is likely not that large of a leak since it only occurs once per radiation source (at the end of its life) and the `RadiationSourceEntry` structs aren't very large. 

2) Larger leak fix. `StarParticleRadTransfer.C` deletes and re-creates the `GlobalRadiationSources` list every call, but this was not being done correctly. Using call to `DeleteRadiationSource` properly now which properly deletes the allocated arrays in the struct.