### PR TITLE
fix ci testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,8 @@ commands:
           pip install --upgrade pip
           pip install --upgrade wheel
           pip install --upgrade setuptools
-          pip install Cython numpy h5py matplotlib fastcache flake8 nose yt girder-client
+          pip install 'matplotlib<3.3.0'
+          pip install Cython numpy h5py fastcache flake8 nose yt girder-client
           # Install hypre
           mkdir -p $HOME/local
           if [ ! -f $HOME/local/lib/libHYPRE.a ]; then
@@ -160,7 +161,7 @@ commands:
 jobs:
   test-suite:
     docker:
-      - image: circleci/python:3.7.2
+      - image: circleci/python:3.8.5
 
     working_directory: ~/enzo-dev
 
@@ -207,7 +208,7 @@ jobs:
 
   test-compile-options:
     docker:
-      - image: circleci/python:3.7.2
+      - image: circleci/python:3.8.5
 
     working_directory: ~/enzo-dev
 
@@ -234,7 +235,7 @@ jobs:
 
   docs-build:
     docker:
-      - image: circleci/python:3.7.2
+      - image: circleci/python:3.8.5
 
     working_directory: ~/enzo-dev
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,73 +4,83 @@ commands:
   set-env:
     description: "Set environment variables."
     steps:
-      - run: |
-          echo 'export LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH' >> $BASH_ENV
-          echo 'export ENZOTEST_DIR=$HOME/enzo_test' >> $BASH_ENV
-          echo 'export ANSWER_NAME="push_suite"' >> $BASH_ENV
-          echo 'export HYPRE=hypre-2.11.2' >> $BASH_ENV
-          # get tags from the main repository (for the current gold standard)
-          git fetch --tags https://github.com/enzo-project/enzo-dev
-          # tag the tip so we can go back to it
-          git tag tip
+      - run:
+          name: "Set environment variables."
+          command: |
+            echo 'export LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH' >> $BASH_ENV
+            echo 'export ENZOTEST_DIR=$HOME/enzo_test' >> $BASH_ENV
+            echo 'export ANSWER_NAME="push_suite"' >> $BASH_ENV
+            echo 'export HYPRE=hypre-2.11.2' >> $BASH_ENV
+            # get tags from the main repository (for the current gold standard)
+            git fetch --tags https://github.com/enzo-project/enzo-dev
+            # tag the tip so we can go back to it
+            git tag tip
 
   install-dependencies:
     description: "Install dependencies."
     steps:
-      - run: |
-          source $BASH_ENV
-          sudo apt-get update
-          sudo apt-get install -y csh libhdf5-serial-dev libopenmpi-dev openmpi-bin gfortran libtool-bin
-          python3 -m venv $HOME/venv
-          source $HOME/venv/bin/activate
-          pip install --upgrade pip
-          pip install --upgrade wheel
-          pip install --upgrade setuptools
-          pip install 'matplotlib<3.3.0'
-          pip install Cython numpy h5py fastcache flake8 nose yt girder-client
-          # Install hypre
-          mkdir -p $HOME/local
-          if [ ! -f $HOME/local/lib/libHYPRE.a ]; then
-            cd $HOME
-            wget https://computation.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods/download/$HYPRE.tar.gz
-            tar xvfz $HYPRE.tar.gz
-            cd $HYPRE/src
-            ./configure --with-MPI --with-MPI-include=/usr/include/mpi --with-MPI-libs=mpi --with-MPI-lib-dirs=/usr/lib --prefix=$HOME/local
-            make install
-          fi
+      - run:
+          name: "Install dependencies."
+          command: |
+            source $BASH_ENV
+            sudo apt-get update
+            sudo apt-get install -y csh libhdf5-serial-dev libopenmpi-dev openmpi-bin gfortran libtool-bin
+            python3 -m venv $HOME/venv
+            source $HOME/venv/bin/activate
+            pip install --upgrade pip
+            pip install --upgrade wheel
+            pip install --upgrade setuptools
+            pip install 'matplotlib<3.3.0'
+            pip install Cython numpy h5py fastcache flake8 nose yt girder-client
+            # Install hypre
+            mkdir -p $HOME/local
+            if [ ! -f $HOME/local/lib/libHYPRE.a ]; then
+              cd $HOME
+              wget https://computation.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods/download/$HYPRE.tar.gz
+              tar xvfz $HYPRE.tar.gz
+              cd $HYPRE/src
+              ./configure --with-MPI --with-MPI-include=/usr/include/mpi --with-MPI-libs=mpi --with-MPI-lib-dirs=/usr/lib --prefix=$HOME/local
+              make install
+            fi
 
   install-grackle:
     description: "Install grackle."
     steps:
-      - run: |
-          git clone -b master https://github.com/grackle-project/grackle $HOME/grackle
-          cd $HOME/grackle
-          ./configure
-          cd src/clib
-          make machine-linux-gnu
-          make
-          make install
+      - run:
+          name: "Install grackle."
+          command: |
+            git clone -b master https://github.com/grackle-project/grackle $HOME/grackle
+            cd $HOME/grackle
+            ./configure
+            cd src/clib
+            make machine-linux-gnu
+            make
+            make install
 
   install-docs-dependencies:
     description: "Install dependencies for docs build."
     steps:
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y dvipng texlive-latex-extra
-          python3 -m venv $HOME/venv
-          source $HOME/venv/bin/activate
-          pip install --upgrade pip
-          pip install --upgrade wheel
-          pip install --upgrade setuptools
-          pip install sphinx
+      - run:
+          name: "Install dependencies for docs build."
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y dvipng texlive-latex-extra
+            python3 -m venv $HOME/venv
+            source $HOME/venv/bin/activate
+            pip install --upgrade pip
+            pip install --upgrade wheel
+            pip install --upgrade setuptools
+            pip install sphinx
 
   download-test-data:
     description: "Download test data."
     steps:
-      - run: |
-          source $BASH_ENV
-          source $HOME/venv/bin/activate
-          girder-cli --api-url https://girder.hub.yt/api/v1 download 5af9ef42ec1bd30001fcd001 $HOME/enzo-dev/run/CosmologySimulation
+      - run:
+          name: "Download test data."
+          command: |
+            source $BASH_ENV
+            source $HOME/venv/bin/activate
+            girder-cli --api-url https://girder.hub.yt/api/v1 download 5af9ef42ec1bd30001fcd001 $HOME/enzo-dev/run/CosmologySimulation
 
   build-and-test:
     description: "Compile enzo and run tests."
@@ -85,78 +95,84 @@ commands:
         type: string
         default: ""
     steps:
-      - run: |
-          source $BASH_ENV
-          source $HOME/venv/bin/activate
-          if [ ! -f << parameters.skipfile >> ]; then
-            git checkout << parameters.tag >>
-            ./configure
-            cd src/enzo
-            make machine-ubuntu
-            make load-config-test-suite
-            make clean
-            make -j 4
-            cd ../../run
-            python ./test_runner.py --suite=push -o $ENZOTEST_DIR --answer-name=$ANSWER_NAME --local --strict=high --verbose << parameters.flags >>
-          fi
+      - run:
+          name: "Compile enzo and run tests."
+          command: |
+            source $BASH_ENV
+            source $HOME/venv/bin/activate
+            if [ ! -f << parameters.skipfile >> ]; then
+              git checkout << parameters.tag >>
+              ./configure
+              cd src/enzo
+              make machine-ubuntu
+              make load-config-test-suite
+              make clean
+              make -j 4
+              cd ../../run
+              python ./test_runner.py --suite=push -o $ENZOTEST_DIR --answer-name=$ANSWER_NAME --local --strict=high --verbose << parameters.flags >>
+            fi
 
   compile-test:
     description: "Test that enzo compiles in a few different configurations."
     steps:
-      - run: |
-          source $BASH_ENV
-          source $HOME/venv/bin/activate
-          ./configure
-          cd src/enzo
-          make machine-ubuntu
-          # test various baryon/particle precisions
-          for prec in 32 64
-          do for part in 32 64 128
-          do
-          # skip the test-suite configuration
-          if [[ $prec == 64 && $part == 64 ]]; then
-          continue
-          fi
-          make precision-$prec
-          make particles-$part
-          make clean
-          make -j 4 || (make show-config ; exit 1)
-          done ; done
-          # return this to default
-          make precision-64
-          make particles-64
-          # test various integer/particle-id precisions
-          for inte in 32 64
-          do for pids in 32 64
-          do
-          # skip the test-suite configuration
-          if [[ $inte == 32 && $pids == 32 ]]; then
-          continue
-          fi
-          make integers-$inte
-          make particle-id-$pids
-          make clean
-          make -j 4 || (make show-config ; exit 1)
-          done ; done
-          make integers-64
-          make particle-id-64
-          # test without mpi
-          make use-mpi-no
-          make clean
-          make -j 4 || (make show-config ; exit 1)
-          make use-mpi-yes
-          # test ray-tracing
-          make photon-no
-          make clean
-          make -j 4 || (make show-config ; exit 1)
+      - run:
+          name: "Test compilation configurations."
+          command: |
+            source $BASH_ENV
+            source $HOME/venv/bin/activate
+            ./configure
+            cd src/enzo
+            make machine-ubuntu
+            # test various baryon/particle precisions
+            for prec in 32 64
+            do for part in 32 64 128
+            do
+            # skip the test-suite configuration
+            if [[ $prec == 64 && $part == 64 ]]; then
+            continue
+            fi
+            make precision-$prec
+            make particles-$part
+            make clean
+            make -j 4 || (make show-config ; exit 1)
+            done ; done
+            # return this to default
+            make precision-64
+            make particles-64
+            # test various integer/particle-id precisions
+            for inte in 32 64
+            do for pids in 32 64
+            do
+            # skip the test-suite configuration
+            if [[ $inte == 32 && $pids == 32 ]]; then
+            continue
+            fi
+            make integers-$inte
+            make particle-id-$pids
+            make clean
+            make -j 4 || (make show-config ; exit 1)
+            done ; done
+            make integers-64
+            make particle-id-64
+            # test without mpi
+            make use-mpi-no
+            make clean
+            make -j 4 || (make show-config ; exit 1)
+            make use-mpi-yes
+            # test ray-tracing
+            make photon-no
+            make clean
+            make -j 4 || (make show-config ; exit 1)
 
   build-docs:
     description: "Test the docs build."
     steps:
-      - run: |
-          source $HOME/venv/bin/activate
-          cd doc/manual/source
-          python -m sphinx -M html "." "_build" -W
+      - run:
+          name: "Test the docs build."
+          command: |
+            source $HOME/venv/bin/activate
+            cd doc/manual/source
+            python -m sphinx -M html "." "_build" -W
 
 jobs:
   test-suite:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,13 +171,13 @@ jobs:
 
       - restore_cache:
           name: "Restore dependencies cache."
-          key: dependencies-v1
+          key: dependencies-v2
 
       - install-dependencies
 
       - save_cache:
           name: "Save dependencies cache"
-          key: dependencies-v1
+          key: dependencies-v2
           paths:
             - ~/.cache/pip
             - ~/venv

--- a/doc/manual/source/conf.py
+++ b/doc/manual/source/conf.py
@@ -224,7 +224,6 @@ intersphinx_mapping = {'http://docs.python.org/': None,
                        'http://ipython.org/ipython-doc/stable/': None,
                        'http://docs.scipy.org/doc/numpy/': None,
                        'http://matplotlib.sourceforge.net/': None,
-                       'http://yt.enzotools.org/doc': None,
                        }
 
 

--- a/doc/manual/source/reference/NestedGridParticles.rst
+++ b/doc/manual/source/reference/NestedGridParticles.rst
@@ -93,17 +93,9 @@ and ``ParticleVelocities files``. ``CosmologySimulationParticleMassName``
 must therefore also be specified as an input in the Enzo parameter
 file.
 
-`Linked here <http://barn.enzotools.org/inits_sort/>`_
-is a simple `Python <http://python.org/>`_ script
-that will fix the initial condition files. After running the
-script, run ring on the new initial condition files. The script
-requires a Python installation that has both
-`Numpy <http://numpy.scipy.org/>`_ and
-`h5py <http://code.google.com/p/h5py/>`_. A simple way to gain an
-installation of Python with these modules is to install
-`yt <http://yt.enzotools.org/>`_, which is one of the
-:doc:`data analysis tools </user_guide/AnalyzingWithYT>`
-available for Enzo.
+.. note:: A long time ago, there was a script available for fixing this at
+   http://barn.enzotools.org/inits_sort. Unfortunately, that has been
+   lost to time.
 
 Procedure
 ---------

--- a/doc/manual/source/supplementary_info/EmbeddedPython.rst
+++ b/doc/manual/source/supplementary_info/EmbeddedPython.rst
@@ -55,7 +55,7 @@ How to Run
 ----------
 
 By constructing a script inside ``user_script.py``, the Enzo hierarchy can be
-accessed and modified. The analysis toolkit `yt <http://yt.enzotools.org/>`_
+accessed and modified. The analysis toolkit `yt <https://yt-project.org/>`__
 has functionality that can abstract much of the data-access and handling.
 Currently several different plotting methods -- profiles, phase plots, slices
 and cutting planes -- along with all derived quantities can be accessed and

--- a/src/enzo/python_bridge/problemtype_handler.pyx
+++ b/src/enzo/python_bridge/problemtype_handler.pyx
@@ -3,7 +3,7 @@ The beginnings of a mechanism for interacting with Enzo through Python
 
 Author: Matthew Turk <matthewturk@gmail.com>
 Affiliation: NSF / Columbia University
-Homepage: http://yt.enzotools.org/
+Homepage: https://yt-project.org/
 License:
   Copyright (C) 2011 Matthew Turk.  All Rights Reserved.
 


### PR DESCRIPTION
The latest major release of matplotlib clashes with the lastest stable yt release, which is why the tests are failing. This avoids installing the clashing matplotlib version. I also went ahead and updated to the latest version of Python for the testing.

The last commit adds names to the circleci script so that the appearance on circleci shows that name and not a smashed together string of all the commands. Unfortunately, it requires everything to go two spaces to the right, but it does make the ci easier to parse.

Apparently the docs build was also failing with a dead intersphinx link, which led me to discover a number of links to yt.enzotools.org, which I have changed to yt-project.org. Unfortunately, we also linked to a script that is no longer available, so I just left a note about that.