### PR TITLE
Exit with error if metal cooling on but no metal field present.

### DIFF
--- a/src/enzo/Grid_GrackleWrapper.C
+++ b/src/enzo/Grid_GrackleWrapper.C
@@ -142,10 +142,7 @@ int grid::GrackleWrapper()
 
   // Double check if there's a metal field when we have metal cooling
   if (MetalCooling && MetalFieldPresent == FALSE) {
-    if (debug)
-      fprintf(stderr, "Warning: No metal field found.  Turning OFF MetalCooling.\n");
-    MetalCooling = FALSE;
-    MetalNum = 0;
+    ENZO_FAIL("Metal cooling is on, but no metal field present.");
   }
 
   /* If both metal fields (Pop I/II and III) exist, create a field


### PR DESCRIPTION
This changes the behavior when metal cooling has been enabled, but there is no metal field present. Previously, we disable metal cooling and keep running. I argue this is not what the user would want. Personally, I would rather the simulation not run instead of running in a way I hadn't intended, especially since the warning statement will most likely be missed. As well, there is a bug here because while `MetalCooling` is set to 0, the corresponding parameter within Grackle is not, so this results in wild behavior as Grackle tries to access `BaryonField[0]` (i.e., the gas density) as the metal density.