### PR TITLE
Fix HDF5 include path

### DIFF
--- a/src/enzo/Make.mach.linux-gnu
+++ b/src/enzo/Make.mach.linux-gnu
@@ -94,7 +94,7 @@ MACH_OPT_AGGRESSIVE  = -O3 -g
 #-----------------------------------------------------------------------
 
 LOCAL_INCLUDES_MPI    = # MPI includes
-LOCAL_INCLUDES_HDF5   = -I$(LOCAL_HDF5_INSTALL) # HDF5 includes
+LOCAL_INCLUDES_HDF5   = -I$(LOCAL_HDF5_INSTALL)/include # HDF5 includes
 LOCAL_INCLUDES_HYPRE  = -I$(LOCAL_HYPRE_INSTALL)/include
 LOCAL_INCLUDES_PAPI   = # PAPI includes
 LOCAL_INCLUDES_GRACKLE = -I$(LOCAL_GRACKLE_INSTALL)/include


### PR DESCRIPTION
`Make.mach.linux-gnu` contains a typo in `LOCAL_INCLUDES_HDF5` that causes the HDF5 header not to be found.