### PR TITLE
Removing DebugField from MHD collapse problem

### DIFF
--- a/src/enzo/GrackleReadParameters.C
+++ b/src/enzo/GrackleReadParameters.C
@@ -218,7 +218,8 @@ int GrackleReadParameters(FILE *fptr, FLOAT InitTime)
   code_units grackle_units;
   grackle_units.a_units = 1.0;
   float DensityUnits = 1.0, LengthUnits = 1.0, TemperatureUnits = 1.0,
-    TimeUnits = 1.0, VelocityUnits = 1.0, MassUnits = 1.0;
+    TimeUnits = 1.0, VelocityUnits = 1.0;
+  double MassUnits = 1.0;
   if (GetUnits(&DensityUnits, &LengthUnits, &TemperatureUnits,
                &TimeUnits, &VelocityUnits, &MassUnits, InitTime) == FAIL) {
     ENZO_FAIL("Error in GetUnits.\n");

--- a/src/enzo/hydro_rk/Grid_CollapseMHD3DInitializeGrid.C
+++ b/src/enzo/hydro_rk/Grid_CollapseMHD3DInitializeGrid.C
@@ -124,8 +124,6 @@ int grid::CollapseMHD3DInitializeGrid(int n_sphere,
     //    FieldType[NumberOfBaryonFields++] = AccelerationField3;
   }
 
-  FieldType[NumberOfBaryonFields++] = DebugField;
-
   /* Return if this doesn't concern us. */
 
   if (ProcessorNumber != MyProcessorNumber) {


### PR DESCRIPTION
This was causing an I/O crash because the data label was never associated with it in the problem initializer. h/t Armin M. on the mailing list for pointing this out.

I'm also including a minor fix to the MassUnits to be double instead of float. This causes compiler issues when using mixed precision.