### PR TITLE
Fixes to the testing infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ commands:
 jobs:
   test-suite:
     docker:
-      - image: circleci/python:3.8.5
+      - image: cimg/python:3.8.5
 
     working_directory: ~/enzo-dev
 
@@ -224,7 +224,7 @@ jobs:
 
   test-compile-options:
     docker:
-      - image: circleci/python:3.8.5
+      - image: cimg/python:3.8.5
 
     working_directory: ~/enzo-dev
 
@@ -251,7 +251,7 @@ jobs:
 
   docs-build:
     docker:
-      - image: circleci/python:3.8.5
+      - image: cimg/python:3.8.5
 
     working_directory: ~/enzo-dev
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ commands:
             pip install --upgrade wheel
             pip install --upgrade setuptools
             pip install 'matplotlib<3.3.0'
-            pip install Cython numpy h5py fastcache flake8 nose yt girder-client
+            pip install Cython numpy h5py fastcache flake8 nose yt==3.6.1 girder-client
             # Install hypre
             mkdir -p $HOME/local
             if [ ! -f $HOME/local/lib/libHYPRE.a ]; then

--- a/run/test_runner.py
+++ b/run/test_runner.py
@@ -42,7 +42,7 @@ ytcfg["yt","suppressStreamLogging"] = "True"
 ytcfg["yt","__command_line"] = "True" 
 from yt.mods import *
 
-from yt.utilities.command_line import get_yt_version
+from yt.funcs import get_yt_version
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.logger import \
     disable_stream_logging, ufstring


### PR DESCRIPTION
This PR makes three changes related to testing:

1. It changes circleci -> cimg in the CircleCI config.yml to switch from outdated Ubuntu images.
2. It fixes where get_yt_version is imported from in test (yt 4 no longer supports the old one).
3. It pins the version of yt used for testing to 3.6.1 (which seems to support both get_yt_version imports). This can be reverted once we update the gold standard version to 15.

These changes address some failures showing up in otherwise correct PRs.