### PR TITLE
Increase timeout limit in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ commands:
     steps:
       - run:
           name: "Compile enzo and run tests."
+          no_output_timeout: 20m
           command: |
             source $BASH_ENV
             source $HOME/venv/bin/activate


### PR DESCRIPTION
This PR increase the timeout limit in the testing infrastructure from the default of 10 minutes to 20 minutes. This appears to be the cause of recent test failures -- in particular, the cosmology simulation test was exceeding 10 minutes (i.e. 600 seconds). It is not clear why this changed (typical run times for this test in the past seem to be ~300-400 seconds) -- it may be the new images adopted in PR#179 or simply variation depending on local run conditions.