### PR TITLE
Corrected min/max reporting in performance.h

### DIFF
--- a/src/enzo/EnzoTiming.h
+++ b/src/enzo/EnzoTiming.h
@@ -30,12 +30,12 @@
 #include <map>
 
 template <typename T>
-bool min(const T& A, const T& B) {
+T min(const T& A, const T& B) {
   return A < B ? A : B;
 }
 
 template <typename T>
-bool max(const T& A, const T& B) {
+T max(const T& A, const T& B) {
   return A > B ? A : B;
 }
 


### PR DESCRIPTION
For some reason, the min/max functions returned bool types instead of the templated type T. After this change, performance.h now reports the correct min/max values for each performance timer.

There is only 1 effective commit in this PR with the first one (b833391) being already incorporated into another PR and the others being merges. Whoever merges this PR should rebase/squash to remove them.