### PR TITLE
Make all global_data.h declarations on their own line

### DIFF
--- a/src/enzo/global_data.h
+++ b/src/enzo/global_data.h
@@ -114,7 +114,8 @@ EXTERN hydro_method HydroMethod;
 /* Large and small numbers (i.e. compared to any real quantity).  This may
    be machine and problem dependent. */
 
-EXTERN float huge_number, tiny_number;
+EXTERN float huge_number;
+EXTERN float tiny_number;
 
 /* Gamma: Ideal gas law constant. */
 
@@ -239,7 +240,8 @@ EXTERN int NumberOfBufferZones;
 
 /* The left and right boundaries of the entire computational domain. */
 
-EXTERN FLOAT DomainLeftEdge[MAX_DIMENSION], DomainRightEdge[MAX_DIMENSION];
+EXTERN FLOAT DomainLeftEdge[MAX_DIMENSION];
+EXTERN FLOAT DomainRightEdge[MAX_DIMENSION];
 
 /* Velocity of entire computational domain. */
 
@@ -247,19 +249,20 @@ EXTERN float GridVelocity[MAX_DIMENSION];
 
 /* HDF names for labels and scales. */
 
-EXTERN char *DimUnits[MAX_DIMENSION], *DimLabels[MAX_DIMENSION];
+EXTERN char *DimUnits[MAX_DIMENSION];
+EXTERN char *DimLabels[MAX_DIMENSION];
 EXTERN char *DataLabel[MAX_NUMBER_OF_BARYON_FIELDS];
 EXTERN char *DataUnits[MAX_NUMBER_OF_BARYON_FIELDS];
 
 /* Region in which refinement is allowed (in problem space). */
 
-EXTERN FLOAT RefineRegionLeftEdge[MAX_DIMENSION], 
-             RefineRegionRightEdge[MAX_DIMENSION];
+EXTERN FLOAT RefineRegionLeftEdge[MAX_DIMENSION];
+EXTERN FLOAT RefineRegionRightEdge[MAX_DIMENSION];
 EXTERN int RefineRegionAutoAdjust;
 
 EXTERN int MultiRefineRegion;
-EXTERN FLOAT MultiRefineRegionLeftEdge[MAX_STATIC_REGIONS][MAX_DIMENSION], 
-             MultiRefineRegionRightEdge[MAX_STATIC_REGIONS][MAX_DIMENSION];
+EXTERN FLOAT MultiRefineRegionLeftEdge[MAX_STATIC_REGIONS][MAX_DIMENSION];
+EXTERN FLOAT MultiRefineRegionRightEdge[MAX_STATIC_REGIONS][MAX_DIMENSION];
 EXTERN int MultiRefineRegionGeometry[MAX_STATIC_REGIONS];
 EXTERN FLOAT MultiRefineRegionCenter[MAX_STATIC_REGIONS][MAX_DIMENSION];
 EXTERN FLOAT MultiRefineRegionOrientation[MAX_STATIC_REGIONS][MAX_DIMENSION];
@@ -273,7 +276,8 @@ EXTERN FLOAT MultiRefineRegionStaggeredRefinement[MAX_STATIC_REGIONS];
 
 /* Uniform gravity: on/off flag, direction, and strength. */
 
-EXTERN int UniformGravity, UniformGravityDirection;
+EXTERN int UniformGravity;
+EXTERN int UniformGravityDirection;
 EXTERN float UniformGravityConstant;
 
 /* point source gravity: on/off flag position, and strength. */
@@ -285,8 +289,8 @@ EXTERN float PointSourceGravityCoreRadius;
 
 /* disk gravity */
 EXTERN int DiskGravity;
-EXTERN FLOAT DiskGravityPosition[MAX_DIMENSION],
-             DiskGravityAngularMomentum[MAX_DIMENSION];
+EXTERN FLOAT DiskGravityPosition[MAX_DIMENSION];
+EXTERN FLOAT DiskGravityAngularMomentum[MAX_DIMENSION];
 EXTERN float DiskGravityStellarDiskMass;
 EXTERN float DiskGravityStellarDiskScaleHeightR;
 EXTERN float DiskGravityStellarDiskScaleHeightz;
@@ -639,7 +643,8 @@ EXTERN float DepositPositionsParticleSmoothRadius;
    The minimum pressure jump required to be a shock.
    The minimum internal/total energy ratio for a shock. */
 
-EXTERN float MinimumPressureJumpForRefinement, MinimumEnergyRatioForRefinement;
+EXTERN float MinimumPressureJumpForRefinement;
+EXTERN float MinimumEnergyRatioForRefinement;
 
 /* For CellFlaggingMethod = 6,
    The number of cells by which the Jeans length should be resolved. */
@@ -669,8 +674,8 @@ EXTERN float MustRefineParticlesMinimumMass;
 /* For CellFlaggingMethod = 8,
    region in which particles are flagged as MustRefine particles */
 
-EXTERN FLOAT MustRefineParticlesLeftEdge[MAX_DIMENSION], 
-             MustRefineParticlesRightEdge[MAX_DIMENSION];
+EXTERN FLOAT MustRefineParticlesLeftEdge[MAX_DIMENSION];
+EXTERN FLOAT MustRefineParticlesRightEdge[MAX_DIMENSION];
 
 /* For CellFlaggingMethod = 8,
    binary switch that allows must refine particles to be created by the 
@@ -796,10 +801,17 @@ EXTERN double timer[MAX_COUNTERS];
 EXTERN int counter[MAX_COUNTERS];
 EXTERN FILE *filePtr;
 EXTERN char tracename[MAX_NAME_LENGTH];
-EXTERN double starttime, endtime;
-EXTERN double Start_Wall_Time, End_Wall_Time, WallTime;
-EXTERN int flagging_count, in_count, out_count, moving_count;
-EXTERN float flagging_pct, moving_pct;
+EXTERN double starttime;
+EXTERN double endtime;
+EXTERN double Start_Wall_Time;
+EXTERN double End_Wall_Time;
+EXTERN double WallTime;
+EXTERN int flagging_count;
+EXTERN int in_count;
+EXTERN int out_count;
+EXTERN int moving_count;
+EXTERN float flagging_pct;
+EXTERN float moving_pct;
 #endif /* MPI_INSTRUMENTATION */
 EXTERN char name[MAX_NAME_LENGTH];
 EXTERN FILE *tracePtr;
@@ -820,7 +832,8 @@ EXTERN char *NewMovieName;
 EXTERN int NewMovieDumpNumber;
 EXTERN int NewMovieParticleOn;
 EXTERN FLOAT *StarParticlesOnProcOnLvl_Position[128][3]; 
-EXTERN float *StarParticlesOnProcOnLvl_Velocity[128][3], *StarParticlesOnProcOnLvl_Mass[128];
+EXTERN float *StarParticlesOnProcOnLvl_Velocity[128][3];
+EXTERN float *StarParticlesOnProcOnLvl_Mass[128];
 EXTERN float *StarParticlesOnProcOnLvl_Attr[128][MAX_NUMBER_OF_PARTICLE_ATTRIBUTES];
 EXTERN int *StarParticlesOnProcOnLvl_Type[128];
 EXTERN PINT *StarParticlesOnProcOnLvl_Number[128];


### PR DESCRIPTION
This is designed to be a no-op change.  What it does is move all variable definitions in `global_data.h` to their own line, which makes parsing the file easier.

This is in preparation for a forthcoming PR to add support for `libyt` and move to Python 3.