### PR TITLE
Fix C++11 compile-errors

### DIFF
--- a/src/enzo/Grid.h
+++ b/src/enzo/Grid.h
@@ -1127,7 +1127,7 @@ gradient force to gravitational force for one-zone collapse test. */
    };
 
    void PrintBaryonFieldValues(int field, int index)
-     {fprintf(stdout, "Baryonfield[field = %"ISYM"][index = %"ISYM"] = %g\n", 
+     {fprintf(stdout, "Baryonfield[field = %" ISYM "][index = %" ISYM "] = %g\n", 
 	      field, index, BaryonField[field][index]);};
 
 // -------------------------------------------------------------------------

--- a/src/enzo/PhotonPackage.h
+++ b/src/enzo/PhotonPackage.h
@@ -56,12 +56,12 @@ public:
     pix2vec_nest64((int64_t)(1 << level), ipix, u);
     for (int dim = 0; dim < 3; dim++) 
       r[dim] = SourcePosition[dim] + u[dim] * Radius;
-    printf("Photons = %g, Type = %"ISYM", Radius = %"PSYM"\n", Photons, Type, Radius);
+    printf("Photons = %g, Type = %" ISYM ", Radius = %" PSYM "\n", Photons, Type, Radius);
     printf("ipix = %lld, level = %ld\n", ipix, level);
-    printf("normal = %"PSYM" %"PSYM" %"PSYM"\n", u[0], u[1], u[2]);
-    printf("SourcePosition = %"PSYM" %"PSYM" %"PSYM"\n",
+    printf("normal = %" PSYM " %" PSYM " %" PSYM "\n", u[0], u[1], u[2]);
+    printf("SourcePosition = %" PSYM " %" PSYM " %" PSYM "\n",
 	   SourcePosition[0], SourcePosition[1], SourcePosition[2]);
-    printf("RayPosition = %"PSYM" %"PSYM" %"PSYM"\n", r[0], r[1], r[2]);
+    printf("RayPosition = %" PSYM " %" PSYM " %" PSYM "\n", r[0], r[1], r[2]);
     return;
   };
 


### PR DESCRIPTION
Another extremely minor PR.  When I was dealing with a number of self-inflicted compile-time errors, I was getting lots and lots of output about the literals needing spaces in C++11.  This fixed those and made it a lot easier for me to pick out all the stuff *I* broke.
