### PR TITLE
Add Make.mach.conda

### DIFF
--- a/src/enzo/Make.mach.conda
+++ b/src/enzo/Make.mach.conda
@@ -1,0 +1,116 @@
+#=======================================================================
+#
+# FILE:        Make.mach.conda
+#
+# DESCRIPTION: Using a conda environment for your enzo build.
+#              This requires the conda packages:
+#                   - gxx_linux-64
+#                   - gcc_linux-64
+#                   - mpi4py
+#                   - hdf5
+#
+#              conda-forge seems the most reliable for these.
+#
+# AUTHOR:      Matthew Turk <matthewturk@gmail.com>
+#
+# DATE:        2022-10-12
+#
+#=======================================================================
+
+MACH_TEXT  = Conda environment
+MACH_VALID = 1
+MACH_FILE  = Make.mach.conda
+
+#-----------------------------------------------------------------------
+# Install paths (local variables)
+#-----------------------------------------------------------------------
+
+LOCAL_GRACKLE_INSTALL = /usr/local
+
+#-----------------------------------------------------------------------
+# Compiler settings
+#-----------------------------------------------------------------------
+
+MACH_CPP       = cpp # C preprocessor command
+
+# With MPI
+
+MACH_CC_MPI    = mpicc # C compiler when using MPI
+MACH_CXX_MPI   = mpic++ # C++ compiler when using MPI
+MACH_FC_MPI    = gfortran # Fortran 77 compiler when using MPI
+MACH_F90_MPI   = gfortran # Fortran 90 compiler when using MPI
+MACH_LD_MPI    = mpic++ # Linker when using MPI
+
+# Without MPI
+
+MACH_CC_NOMPI  = gcc # C compiler when not using MPI
+MACH_CXX_NOMPI = g++ # C++ compiler when not using MPI
+MACH_FC_NOMPI  = gfortran # Fortran 77 compiler when not using MPI
+MACH_F90_NOMPI = gfortran # Fortran 90 compiler when not using MPI
+MACH_LD_NOMPI  = g++ # Linker when not using MPI
+
+#-----------------------------------------------------------------------
+# Machine-dependent defines
+#-----------------------------------------------------------------------
+
+# Note: When compiling against HDF5 version 1.8 or greater, you need to
+# compile HDF5 with --with-default-api-version=v16, or Enzo with
+# -DH5_USE_16_API.
+
+MACH_DEFINES   = -DLINUX -DH5_USE_16_API
+
+#-----------------------------------------------------------------------
+# Compiler flag settings
+#-----------------------------------------------------------------------
+
+MACH_CPPFLAGS = -P -traditional 
+MACH_CFLAGS   = 
+MACH_CXXFLAGS =
+MACH_FFLAGS   = -fno-second-underscore -ffixed-line-length-132 -std=legacy
+MACH_F90FLAGS = -fno-second-underscore -std=legacy
+MACH_LDFLAGS  = 
+
+#-----------------------------------------------------------------------
+# Optimization flags
+#-----------------------------------------------------------------------
+
+MACH_OPT_WARN        = -Wall -g
+MACH_OPT_DEBUG       = -g
+MACH_OPT_HIGH        = -O2
+MACH_OPT_AGGRESSIVE  = -O3 -g
+
+#-----------------------------------------------------------------------
+# Includes
+#-----------------------------------------------------------------------
+
+LOCAL_INCLUDES_MPI    = # MPI includes
+LOCAL_INCLUDES_HDF5   = -I${CONDA_PREFIX}/include/ # HDF5 includes
+LOCAL_INCLUDES_HYPRE  = -I$(LOCAL_HYPRE_INSTALL)/include # hypre includes
+LOCAL_INCLUDES_PAPI   = # PAPI includes
+LOCAL_INCLUDES_GRACKLE = -I$(LOCAL_GRACKLE_INSTALL)/include
+
+MACH_INCLUDES         = $(LOCAL_INCLUDES_HDF5)
+MACH_INCLUDES_MPI     = $(LOCAL_INCLUDES_MPI)
+MACH_INCLUDES_HYPRE   = $(LOCAL_INCLUDES_HYPRE)
+MACH_INCLUDES_PAPI    = $(LOCAL_INCLUDES_PAPI)
+MACH_INCLUDES_GRACKLE = $(LOCAL_INCLUDES_GRACKLE)
+
+#-----------------------------------------------------------------------
+# Libraries
+#-----------------------------------------------------------------------
+
+LOCAL_LIBS_MPI    = # MPI libraries
+LOCAL_LIBS_HDF5   = -L${CONDA_PREFIX}/lib/ -lhdf5 -lz # HDF5 libraries
+LOCAL_LIBS_HYPRE  = -L$(LOCAL_HYPRE_INSTALL)/lib -lHYPRE # hypre libraries
+LOCAL_LIBS_PAPI   = # PAPI libraries
+LOCAL_LIBS_MACH   = -lgfortran # Machine-dependent libraries
+LOCAL_LIBS_GRACKLE = -L$(LOCAL_GRACKLE_INSTALL)/lib -lgrackle
+LOCAL_LIBS_PYTHON = -L${CONDA_PREFIX}/lib/ -lpython3
+LOCAL_LIBS_LIBYT  = $(LOCAL_LIBS_PYTHON) -L${CONDA_PREFIX}/lib/ -lyt -lreadline
+
+MACH_LIBS         = $(LOCAL_LIBS_HDF5) $(LOCAL_LIBS_MACH)
+MACH_LIBS_MPI     = $(LOCAL_LIBS_MPI)
+MACH_LIBS_HYPRE   = $(LOCAL_LIBS_HYPRE)
+MACH_LIBS_PAPI    = $(LOCAL_LIBS_PAPI)
+MACH_LIBS_GRACKLE = $(LOCAL_LIBS_GRACKLE)
+MACH_LIBS_LIBYT   = $(LOCAL_LIBS_LIBYT)


### PR DESCRIPTION
It can be convenient to install using a conda environment.  This adds a makefile that uses a conda environment for its packages.

In some specific cases, this becomes extra useful for using embedded python via libyt, which will be addressed in a forthcoming PR.
