### PR TITLE
removed intersphinx examples in deprecated format

### DIFF
--- a/doc/manual/source/conf.py
+++ b/doc/manual/source/conf.py
@@ -219,11 +219,3 @@ man_pages = [
      [u'Enzo Developers'], 1)
 ]
 
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None,
-                       'http://ipython.org/ipython-doc/stable/': None,
-                       'http://docs.scipy.org/doc/numpy/': None,
-                       'http://matplotlib.sourceforge.net/': None,
-                       }
-
-


### PR DESCRIPTION
Quick fix for failed docs build (removed what seems like unused intersphinx examples that use deprecated format).