### PR TITLE
Updating intersphinx syntax and readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,7 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    

--- a/doc/manual/source/conf.py
+++ b/doc/manual/source/conf.py
@@ -26,7 +26,8 @@ import sys, os
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 sys.path.append(os.path.abspath('exts'))
-extensions = ['sphinx.ext.imgmath', 'youtube']
+extensions = ['sphinx.ext.imgmath',  'sphinx.ext.intersphinx',
+              'youtube']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -217,3 +218,9 @@ man_pages = [
     ('index', 'enzo', u'Enzo Documentation',
      [u'Enzo Developers'], 1)
 ]
+
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
+                       'ipython': ('https://ipython.org/ipython-doc/stable/', None),
+                       'scipy': ('https://numpy.org/doc/stable/', None), 
+                       'matplotlib': ('https://matplotlib.org/stable/', None)
+                       }

--- a/doc/manual/source/conf.py
+++ b/doc/manual/source/conf.py
@@ -26,8 +26,7 @@ import sys, os
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 sys.path.append(os.path.abspath('exts'))
-extensions = ['sphinx.ext.imgmath',  'sphinx.ext.intersphinx',
-              'youtube']
+extensions = ['sphinx.ext.imgmath', 'youtube']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -218,12 +217,3 @@ man_pages = [
     ('index', 'enzo', u'Enzo Documentation',
      [u'Enzo Developers'], 1)
 ]
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None,
-                       'http://ipython.org/ipython-doc/stable/': None,
-                       'http://docs.scipy.org/doc/numpy/': None,
-                       'http://matplotlib.sourceforge.net/': None,
-                       }
-
-


### PR DESCRIPTION
Intersphinx isn't supported in sphinx v7.0, so I'm removing it. The same was done by @mabruzzo in Enzo-E (enzo-project/enzo-e#305).