### PR TITLE
Very small GalaxySimulation fix (to initialize particle boundary type)

### DIFF
--- a/src/enzo/GalaxySimulationInitialize.C
+++ b/src/enzo/GalaxySimulationInitialize.C
@@ -494,6 +494,7 @@ int GalaxySimulationInitialize(FILE *fptr, FILE *Outfptr,
     if (MetaData.TopGridRank > 2)
       Exterior.InitializeExternalBoundaryFace(2, inflow, outflow,
 					      InflowValue, Dummy);
+    Exterior.InitializeExternalBoundaryParticles(MetaData.ParticleBoundaryType);
 	
     /* Set Global Variables for RPS Wind (see ExternalBoundary_SetGalaxySimulationBoundary.C)*/
 


### PR DESCRIPTION
Added small change to GalaxySimulation to initialize the correct particle boundary in the exterior boundary condition.