### PR TITLE
Addressing issue #219 with incorrect particle mass

### DIFF
--- a/src/enzo/Grid_NestedCosmologySimulationInitializeGrid.C
+++ b/src/enzo/Grid_NestedCosmologySimulationInitializeGrid.C
@@ -1474,19 +1474,6 @@ int grid::NestedCosmologySimulationInitializeGrid(
 
 	if (CosmologySimulationManuallySetParticleMassRatio == FALSE) {
 
-	  // If there are exactly 1/8 as many particles as cells,
-	  // then set the particle mass to 8 times the usual
-    
-	  int NumberOfActiveCells = (GridEndIndex[0]-GridStartIndex[0]+1)*
-	    (GridEndIndex[1]-GridStartIndex[1]+1)*
-	    (GridEndIndex[2]-GridStartIndex[2]+1);
-	  if (NumberOfParticles*8 == NumberOfActiveCells)
-	    UniformParticleMass *= 8;
-	  if (NumberOfParticles == NumberOfActiveCells*8)
-	    UniformParticleMass /= 8;
- 
-	  //      UniformParticleMass *= float(POW(TotalRefinement, GridRank));
- 
 	  // Issue a warning if PPIO or PRGIO are on (possibility of errors
 	  // being caused)
 	  if( ((ParallelParticleIO == TRUE) || (ParallelRootGridIO == TRUE)) &&


### PR DESCRIPTION
Removed the particle mass multiplier added for init ICs in Grid_NestedCosmologySimulationInitializeGrid.C that can cause errors with MUSIC ICs as described in the issue #219 .