### PR TITLE
Added StarFormationOncePerRootGridTimeStep to Normal Star

### DIFF
--- a/doc/manual/source/parameters/index.rst
+++ b/doc/manual/source/parameters/index.rst
@@ -2266,6 +2266,12 @@ The parameters below are considered in ``StarParticleCreation`` method
     the particle creation time by this amount.  This value is in units of Myrs.  If set
     to a negative value, energy, mass and metals are injected gradually in the same way as is
     done for ``StarParticleFeedback`` method = 1.  Default -1.
+``StarFormationOncePerRootGridTimeStep`` (external)
+    Only valid for ``StarParticleFeedback`` methods 1 and 11. Star formation will only
+    occur at the beginning of the root grid step and with a mass proportional to the root grid timestep.
+    Stars can still only form on the most refined grid in a given volume. This option
+    results in fewer, more massive star particles.
+    Default: 0 (off)
 ``StarMakerMinimumMassRamp`` (external)
      Sets the Minimum Stellar Mass (otherwise given by ``StarMakerMinimumMass`` to 
      ramp up over time, so that a small mass can be used early in the calculation
@@ -2353,8 +2359,6 @@ The parameters below are considered in ``StarParticleCreation`` method 11.
 ``H2StarMakerH2FloorInColdGas`` (external)
     See :ref:`molecular_hydrogen_regulated_star_formation`.
 ``H2StarMakerColdGasTemperature`` (external)
-    See :ref:`molecular_hydrogen_regulated_star_formation`.
-``StarFormationOncePerRootGridTimeStep`` (external)
     See :ref:`molecular_hydrogen_regulated_star_formation`.
 
 .. _popIII_star_formation_parameters:

--- a/doc/manual/source/physics/star_particles.rst
+++ b/doc/manual/source/physics/star_particles.rst
@@ -441,10 +441,11 @@ applied, below which no star formation occurs.
 
 Typically this method is used with
 ``StarFormationOncePerRootGridTimeStep``, in which case SF occurs only
-at the beginning of the root grid step and only for grids on
-MaximumRefinementLevel, but with a star particle mass that is
+at the beginning of the root grid step and with a star particle mass that is
 proportial to the root grid time step (as opposed to the much smaller
-time step of the maximally refined grid). This results in fewer and
+time step of the maximally refined grid). Star particles will still only
+form on the most refined grid in a given region.
+This results in fewer and
 more massive star particles, which improves computational
 efficiency. Even so, it may be desirable to enforce a lower limit to
 the star particle mass in some cases. This can be done with the

--- a/src/enzo/EvolveLevel.C
+++ b/src/enzo/EvolveLevel.C
@@ -409,7 +409,7 @@ int EvolveLevel(TopGridData *MetaData, LevelHierarchyEntry *LevelArray[],
     /* Currently (September 2023) this is only implemented for H2REG_STAR
     and NORMAL_STAR. MakeStars is completely ignored in all other star makers. */
 
-    if ( (STARMAKE_METHOD(H2REG_STAR)) && 
+    if ( (STARMAKE_METHOD(H2REG_STAR) || STARMAKE_METHOD(NORMAL_STAR)) && 
 	 (level==0) && 
 	 (StarFormationOncePerRootGridTimeStep) ) {
       /* At top level, set Grid::MakeStars to 1 for all highest

--- a/src/enzo/EvolveLevel.C
+++ b/src/enzo/EvolveLevel.C
@@ -406,21 +406,21 @@ int EvolveLevel(TopGridData *MetaData, LevelHierarchyEntry *LevelArray[],
     prevent further star formation until the next root grid time
     step. */
 
-    /* Currently (April 2012) this is only implemented for H2REG_STAR,
-    and MakeStars is completely ignored in all other star makers. */
+    /* Currently (September 2023) this is only implemented for H2REG_STAR
+    and NORMAL_STAR. MakeStars is completely ignored in all other star makers. */
 
     if ( (STARMAKE_METHOD(H2REG_STAR)) && 
 	 (level==0) && 
 	 (StarFormationOncePerRootGridTimeStep) ) {
       /* At top level, set Grid::MakeStars to 1 for all highest
-	 refinement level grids. */
+        refinement level grids. */
       LevelHierarchyEntry *Temp;
       Temp = LevelArray[MaximumRefinementLevel];
       int count=0;
       while (Temp != NULL) {
-	Temp->GridData->SetMakeStars();
-	Temp = Temp->NextGridThisLevel;
-	count++;
+        Temp->GridData->SetMakeStars();
+        Temp = Temp->NextGridThisLevel;
+        count++;
       }
       // if(MyProcessorNumber == ROOT_PROCESSOR) 
       // 	fprintf(stderr,"Set MakeStars=1 for %d MaximumRefinementLevel grids.\n",count);

--- a/src/enzo/EvolveLevel.C
+++ b/src/enzo/EvolveLevel.C
@@ -412,18 +412,17 @@ int EvolveLevel(TopGridData *MetaData, LevelHierarchyEntry *LevelArray[],
     if ( (STARMAKE_METHOD(H2REG_STAR) || STARMAKE_METHOD(NORMAL_STAR)) && 
 	 (level==0) && 
 	 (StarFormationOncePerRootGridTimeStep) ) {
-      /* At top level, set Grid::MakeStars to 1 for all highest
-        refinement level grids. */
+      /* At top level, set Grid::MakeStars to 1 for all grids.
+         Individual star maker routines will need to check
+         whether or not each cell is the highest refined. */
       LevelHierarchyEntry *Temp;
-      Temp = LevelArray[MaximumRefinementLevel];
-      int count=0;
-      while (Temp != NULL) {
-        Temp->GridData->SetMakeStars();
-        Temp = Temp->NextGridThisLevel;
-        count++;
+      for (int i = level; i < MAX_DEPTH_OF_HIERARCHY; i++){
+        Temp = LevelArray[i];
+        while (Temp != NULL) {
+          Temp->GridData->SetMakeStars();
+          Temp = Temp->NextGridThisLevel;
+        }
       }
-      // if(MyProcessorNumber == ROOT_PROCESSOR) 
-      // 	fprintf(stderr,"Set MakeStars=1 for %d MaximumRefinementLevel grids.\n",count);
 
       TopGridTimeStep = LevelArray[0]->GridData->ReturnTimeStep();
 

--- a/src/enzo/Grid.h
+++ b/src/enzo/Grid.h
@@ -148,8 +148,8 @@ class grid
 
 // For once-per-rootgrid-timestep star formation, the following flag
 // determines whether SF is about to occur or not. It's currently
-//(April 2012) only implemented for H2REG_STAR and completely
-// ignored for all other star makers.
+// (September 2023) only implemented for H2REG_STAR and NORMAL_STAR
+// but completely ignored for all other star makers.
   int MakeStars;
 
 //

--- a/src/enzo/Grid_StarParticleHandler.C
+++ b/src/enzo/Grid_StarParticleHandler.C
@@ -806,39 +806,55 @@ int grid::StarParticleHandler(HierarchyEntry* SubgridPointer, int level,
     }
 #endif /* STAR1 */
  
-    if (STARMAKE_METHOD(NORMAL_STAR)) {
+    if (STARMAKE_METHOD(NORMAL_STAR) &&
+       ( this->MakeStars || !StarFormationOncePerRootGridTimeStep )){
 
       //---- MODIFIED CEN OSTRIKER FOLLOWING HOPKINS ET AL 2013 ("STANDARD VERSION")
 
       NumberOfNewParticlesSoFar = NumberOfNewParticles;
+      
+      /* If StarFormationOncePerRootGridTimeStep, use the root grid
+         timestep for the star particle creation. Stars are only
+         created once per root level time step. */
+      float TimeStep;
+      if(StarFormationOncePerRootGridTimeStep)
+         TimeStep = TopGridTimeStep;
+      else
+         TimeStep = dtFixed;
 
       FORTRAN_NAME(star_maker2)(
-       GridDimension, GridDimension+1, GridDimension+2,
-       BaryonField[DensNum], dmfield, temperature, BaryonField[Vel1Num],
-       BaryonField[Vel2Num], BaryonField[Vel3Num], BaryonField[H2INum],
-       cooling_time,
-       &dtFixed, BaryonField[NumberOfBaryonFields], MetalPointer,
-       &CellWidthTemp, &Time, &zred, &MyProcessorNumber,
-       &DensityUnits, &LengthUnits, &VelocityUnits, &TimeUnits,
-       &MaximumNumberOfNewParticles, CellLeftEdge[0], CellLeftEdge[1],
-       CellLeftEdge[2], &GhostZones,
-       &MetallicityField, &HydroMethod, &StarMakerTimeIndependentFormation,
-       &StarMakerMinimumDynamicalTime,
-       &StarMakerVelDivCrit, &StarMakerSelfBoundCrit, 
-       &StarMakerThermalCrit, &StarMakerUseJeansMass, &StarMakerH2Crit, 
-       &StarMakerOverDensityThreshold, &StarMakerMassEfficiency,
-       &StarMakerMinimumMass, &StarMakerTemperatureThreshold,
-       &level, &NumberOfNewParticles, 
-       tg->ParticlePosition[0], tg->ParticlePosition[1],
-          tg->ParticlePosition[2],
-       tg->ParticleVelocity[0], tg->ParticleVelocity[1],
-          tg->ParticleVelocity[2],
-       tg->ParticleMass, tg->ParticleAttribute[1], tg->ParticleAttribute[0],
-       tg->ParticleAttribute[2],
-       &StarMakerTypeIaSNe, BaryonField[MetalIaNum], tg->ParticleAttribute[3]);
+      GridDimension, GridDimension+1, GridDimension+2,
+      BaryonField[DensNum], dmfield, temperature, BaryonField[Vel1Num],
+      BaryonField[Vel2Num], BaryonField[Vel3Num], BaryonField[H2INum],
+      cooling_time,
+      &TimeStep, BaryonField[NumberOfBaryonFields], MetalPointer,
+      &CellWidthTemp, &Time, &zred, &MyProcessorNumber,
+      &DensityUnits, &LengthUnits, &VelocityUnits, &TimeUnits,
+      &MaximumNumberOfNewParticles, CellLeftEdge[0], CellLeftEdge[1],
+      CellLeftEdge[2], &GhostZones,
+      &MetallicityField, &HydroMethod, &StarMakerTimeIndependentFormation,
+      &StarMakerMinimumDynamicalTime,
+      &StarMakerVelDivCrit, &StarMakerSelfBoundCrit, 
+      &StarMakerThermalCrit, &StarMakerUseJeansMass, &StarMakerH2Crit, 
+      &StarMakerOverDensityThreshold, &StarMakerMassEfficiency,
+      &StarMakerMinimumMass, &StarMakerTemperatureThreshold,
+      &level, &NumberOfNewParticles, 
+      tg->ParticlePosition[0], tg->ParticlePosition[1],
+         tg->ParticlePosition[2],
+      tg->ParticleVelocity[0], tg->ParticleVelocity[1],
+         tg->ParticleVelocity[2],
+      tg->ParticleMass, tg->ParticleAttribute[1], tg->ParticleAttribute[0],
+      tg->ParticleAttribute[2],
+      &StarMakerTypeIaSNe, BaryonField[MetalIaNum], tg->ParticleAttribute[3]);
 
       for (i = NumberOfNewParticlesSoFar; i < NumberOfNewParticles; i++)
-          tg->ParticleType[i] = NormalStarType;
+         tg->ParticleType[i] = NormalStarType;
+
+         /* If StarFormationOncePerRootGridTimeStep, reset
+	      this::MakeStars to 0, to prevent further star formation until
+	      next top level time step has been taken. */
+      if(StarFormationOncePerRootGridTimeStep)
+         this->MakeStars = 0;
     }
 
     if (STARMAKE_METHOD(MOM_STAR)) {


### PR DESCRIPTION
Extended existing `StarFormationOncePerRootGridTimeStep` functionality to Normal Star (star_maker2.F). Also adjusted what grids `StarFormationOncePerRootGridTimeStep` triggers on. Previously, it only allowed star formation on grids that were at the maximum refinement level. Since each star maker routine checks that a cell is the most refined representation for its volume, this restriction is unnecessary and prevents star formation in cells where it would otherwise occur.