### PR TITLE
Time Dumps get their own name

### DIFF
--- a/src/enzo/CheckForOutput.C
+++ b/src/enzo/CheckForOutput.C
@@ -159,7 +159,7 @@ int CheckForOutput(HierarchyEntry *TopGrid, TopGridData &MetaData,
     MetaData.TimeLastDataDump += MetaData.dtDataDump;
 
     //#ifdef USE_HDF5_GROUPS
-    Group_WriteAllData(MetaData.DataDumpName, MetaData.DataDumpNumber++,
+    Group_WriteAllData(MetaData.TimeDumpName, MetaData.TimeDumpNumber++,
 		       TopGrid, MetaData, Exterior
 #ifdef TRANSFER
 		       , ImplicitSolver

--- a/src/enzo/Group_WriteAllData.C
+++ b/src/enzo/Group_WriteAllData.C
@@ -273,7 +273,7 @@ int Group_WriteAllData(char *basename, int filenumber,
       if (debug) fprintf(stdout, "Extra dump: %s\n", name);
 
     } // if ExtraDumpName
-    /******************** CYCLE / DT BASED OUTPUTS ********************/
+    /******************** CYCLE BASED OUTPUTS ********************/
  
     if ( (cptr = strstr(basename, MetaData.DataDumpName)) ) {
  
@@ -305,6 +305,66 @@ int Group_WriteAllData(char *basename, int filenumber,
             strcpy(dumpdirname, MetaData.GlobalDir);
             strcat(dumpdirname, "/");
             strcat(dumpdirname, MetaData.DataDumpDir);
+            strcat(dumpdirname, id);
+            // Do mkdir on cpu 0 only
+            strcpy(name, dumpdirname);
+            strcat(name, "/");
+            strcat(name, basename);
+          } // if GlobalDir
+ 
+          else
+ 
+          {
+            // No local or global specified
+            strcpy(name, basename);
+          } // else GlobalDir
+ 
+        } // else LocalDir
+ 
+      } // if DataDumpDir
+ 
+      else
+ 
+      {
+        strcpy(name, basename);
+      } // else DataDumpDir
+ 
+      if (debug) fprintf(stdout, "DATA dump: %s\n", name);
+ 
+    } // if DataDumpName
+
+    /******************** DT BASED OUTPUTS ********************/
+ 
+    if ( (cptr = strstr(basename, MetaData.TimeDumpName)) ) {
+ 
+      if (MetaData.DataDumpDir != NULL)
+      {
+        if (MetaData.LocalDir != NULL) {
+          // Local fs
+          strcpy(dumpdirname, MetaData.LocalDir);
+          strcat(dumpdirname, "/");
+          strcat(dumpdirname, MetaData.TimeDumpDir);
+          strcat(dumpdirname, id);
+  
+          // Create once per node...
+#ifdef USE_NODE_LOCAL
+            strcat(dumpdirname, "/mpi");
+            strcat(dumpdirname, pid);
+#endif /* USE_NODE_LOCAL */
+ 
+          strcpy(name, dumpdirname);
+          strcat(name, "/");
+          strcat(name, basename);
+        } // if LocalDir
+ 
+        else
+ 
+        {
+          if (MetaData.GlobalDir != NULL) {
+            // Global fs
+            strcpy(dumpdirname, MetaData.GlobalDir);
+            strcat(dumpdirname, "/");
+            strcat(dumpdirname, MetaData.TimeDumpDir);
             strcat(dumpdirname, id);
             // Do mkdir on cpu 0 only
             strcpy(name, dumpdirname);
@@ -503,6 +563,7 @@ int Group_WriteAllData(char *basename, int filenumber,
         CommunicationBarrier();
         if( pe == ii )
         {
+            ENZO_FAIL("fail here");
           if ( (cptr = strstr(basename, MetaData.ExtraDumpName)) ) {
             if (MetaData.ExtraDumpDir != NULL) {
 #ifdef SYSCALL
@@ -530,6 +591,18 @@ int Group_WriteAllData(char *basename, int filenumber,
             }
           } // ENDIF datadump
  
+          if ( (cptr = strstr(basename, MetaData.TimeDumpName)) ) {
+            if (MetaData.TimeDumpDir != NULL) {
+#ifdef SYSCALL
+              unixresult = SysMkdir("", dumpdirname);
+              if (debug) fprintf(stdout, "Time dump: dumpdirname=(%s) == unixresult=%"ISYM"\n", dumpdirname, unixresult);
+#else
+              strcat(strcpy(unixcommand, "mkdir -p "), dumpdirname);
+              unixresult = system(unixcommand);
+              if (debug) fprintf(stdout, "Time dump: %s == %"ISYM"\n", unixcommand, unixresult);
+#endif
+            }
+          } // ENDIF datadump
           if ( (cptr = strstr(basename, MetaData.RedshiftDumpName)) ) {
             if (MetaData.RedshiftDumpDir != NULL) {
 #ifdef SYSCALL
@@ -576,9 +649,23 @@ int Group_WriteAllData(char *basename, int filenumber,
 #endif
           }
         } // ENDIF datadump
- 
+          //
         if ( (cptr = strstr(basename, MetaData.DataDumpName)) ) {
           if (MetaData.DataDumpDir != NULL) {
+#ifdef SYSCALL
+            unixresult = SysMkdir("", dumpdirname);
+            if (debug) fprintf(stdout, "DATA dump: dumpdirname=(%s) == unixresult=%"ISYM"\n", dumpdirname, unixresult);
+#else
+            strcat(strcpy(unixcommand, "mkdir -p "), dumpdirname);
+            unixresult = system(unixcommand);
+            if (debug) fprintf(stdout, "DATA dump: %s == %"ISYM"\n", unixcommand, unixresult);
+#endif
+          }
+        } // ENDIF datadump
+ 
+ 
+        if ( (cptr = strstr(basename, MetaData.TimeDumpName)) ) {
+          if (MetaData.TimeDumpDir != NULL) {
 #ifdef SYSCALL
             unixresult = SysMkdir("", dumpdirname);
             if (debug) fprintf(stdout, "DATA dump: dumpdirname=(%s) == unixresult=%"ISYM"\n", dumpdirname, unixresult);

--- a/src/enzo/ReadParameterFile.C
+++ b/src/enzo/ReadParameterFile.C
@@ -204,6 +204,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 
     ret += sscanf(line, "RestartDumpNumber = %"ISYM, &MetaData.RestartDumpNumber);
     ret += sscanf(line, "DataDumpNumber    = %"ISYM, &MetaData.DataDumpNumber);
+    ret += sscanf(line, "TimeDumpNumber    = %"ISYM, &MetaData.TimeDumpNumber);
     ret += sscanf(line, "HistoryDumpNumber = %"ISYM, &MetaData.HistoryDumpNumber);
     ret += sscanf(line, "TracerParticleDumpNumber = %"ISYM, &MetaData.TracerParticleDumpNumber);
 
@@ -211,6 +212,8 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
       MetaData.RestartDumpName = dummy;
     if (sscanf(line, "DataDumpName         = %s", dummy) == 1)
       MetaData.DataDumpName = dummy;
+    if (sscanf(line, "TimeDumpName         = %s", dummy) == 1)
+      MetaData.TimeDumpName = dummy;
     if (sscanf(line, "HistoryDumpName      = %s", dummy) == 1)
       MetaData.HistoryDumpName = dummy;
     if (sscanf(line, "TracerParticleDumpName = %s", dummy) == 1)
@@ -222,6 +225,8 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
       MetaData.RestartDumpDir = dummy;
     if (sscanf(line, "DataDumpDir         = %s", dummy) == 1)
       MetaData.DataDumpDir = dummy;
+    if (sscanf(line, "TimeDumpDir         = %s", dummy) == 1)
+      MetaData.TimeDumpDir = dummy;
     if (sscanf(line, "HistoryDumpDir      = %s", dummy) == 1)
       MetaData.HistoryDumpDir = dummy;
     if (sscanf(line, "TracerParticleDumpDir = %s", dummy) == 1)

--- a/src/enzo/SetDefaultGlobalValues.C
+++ b/src/enzo/SetDefaultGlobalValues.C
@@ -31,6 +31,7 @@ char *DefaultDimLabel[] = {"x", "y", "z"};
  
 char DefaultRestartName[] = "restart";
 char DefaultDataName[] = "data";
+char DefaultTimeName[] = "time";
 char DefaultHistoryName[] = "history";
 char DefaultRedshiftName[] = "RedshiftOutput";
 char DefaultNewMovieName[] = "MoviePack";
@@ -38,6 +39,7 @@ char DefaultTracerParticleName[] = "TracerOutput";
  
 char DefaultRestartDir[] = "RS";
 char DefaultDataDir[] = "DD";
+char DefaultTimeDir[] = "TT";
 char DefaultHistoryDir[] = "HD";
 char DefaultRedshiftDir[] = "RD";
 char DefaultTracerParticleDir[] = "TD";
@@ -106,6 +108,9 @@ int SetDefaultGlobalValues(TopGridData &MetaData)
   MetaData.DataDumpNumber      = 0;
   MetaData.DataDumpName        = DefaultDataName;
   MetaData.DataDumpDir         = DefaultDataDir;
+  MetaData.TimeDumpNumber      = 0;
+  MetaData.TimeDumpName        = DefaultTimeName;
+  MetaData.TimeDumpDir         = DefaultTimeDir;
   MetaData.HistoryDumpNumber   = 0;
   MetaData.HistoryDumpName     = DefaultHistoryName;
   MetaData.HistoryDumpDir      = DefaultHistoryDir;

--- a/src/enzo/TopGridData.h
+++ b/src/enzo/TopGridData.h
@@ -89,12 +89,14 @@ struct TopGridData
 
   int RestartDumpNumber;        // number appended to end of restart dump name
   int DataDumpNumber;           // number appended to end of data dump name
+  int TimeDumpNumber;           // number appended to end of data dump name
   int HistoryDumpNumber;        // number appended to end of history dump
   int MovieDumpNumber;          // number appended to end of movie dump name
   int TracerParticleDumpNumber; // number of dump
 
   char *RestartDumpName;         // restart dump base name
   char *DataDumpName;            // data dump base name
+  char *TimeDumpName;            // data dump base name
   char *HistoryDumpName;         // history dump base name
   char *MovieDumpName;           // movie dump base name
   char *TracerParticleDumpName;  // movie dump name
@@ -102,6 +104,7 @@ struct TopGridData
 
   char *RestartDumpDir;         // restart dump directory name
   char *DataDumpDir;            // data dump directory name
+  char *TimeDumpDir;            // data dump directory name
   char *HistoryDumpDir;         // history dump directory name
   char *MovieDumpDir;           // movie dump directory name
   char *TracerParticleDumpDir;  // tracer particle dump directory name

--- a/src/enzo/WriteParameterFile.C
+++ b/src/enzo/WriteParameterFile.C
@@ -208,12 +208,14 @@ int WriteParameterFile(FILE *fptr, TopGridData &MetaData, char *name = NULL)
  
   fprintf(fptr, "RestartDumpNumber   = %"ISYM"\n", MetaData.RestartDumpNumber);
   fprintf(fptr, "DataDumpNumber      = %"ISYM"\n", MetaData.DataDumpNumber);
+  fprintf(fptr, "TimeDumpNumber      = %"ISYM"\n", MetaData.TimeDumpNumber);
   fprintf(fptr, "HistoryDumpNumber   = %"ISYM"\n", MetaData.HistoryDumpNumber);
   fprintf(fptr, "TracerParticleDumpNumber = %"ISYM"\n",
           MetaData.TracerParticleDumpNumber);
  
   fprintf(fptr, "RestartDumpName     = %s\n", MetaData.RestartDumpName);
   fprintf(fptr, "DataDumpName        = %s\n", MetaData.DataDumpName);
+  fprintf(fptr, "TimeDumpName        = %s\n", MetaData.TimeDumpName);
   fprintf(fptr, "HistoryDumpName     = %s\n", MetaData.HistoryDumpName);
   fprintf(fptr, "TracerParticleDumpName = %s\n",
           MetaData.TracerParticleDumpName);
@@ -223,6 +225,8 @@ int WriteParameterFile(FILE *fptr, TopGridData &MetaData, char *name = NULL)
     fprintf(fptr, "RestartDumpDir        = %s\n", MetaData.RestartDumpDir);
   if (MetaData.DataDumpDir != NULL)
     fprintf(fptr, "DataDumpDir           = %s\n", MetaData.DataDumpDir);
+  if (MetaData.TimeDumpDir != NULL)
+    fprintf(fptr, "TimeDumpDir           = %s\n", MetaData.TimeDumpDir);
   if (MetaData.HistoryDumpDir != NULL)
     fprintf(fptr, "HistoryDumpDir        = %s\n", MetaData.HistoryDumpDir);
   if (MetaData.TracerParticleDumpDir != NULL)

--- a/src/enzo/init_random_seed.F
+++ b/src/enzo/init_random_seed.F
@@ -18,8 +18,8 @@ c=======================================================================
 
       INTG_PREC in_seed
 
-      integer*4 i, n
-      integer*4, allocatable :: seed(:)
+      integer i, n
+      integer, allocatable :: seed(:)
 
       call random_seed(size=n)
       allocate(seed(n))


### PR DESCRIPTION
This PR changes the output labeling and numbering for time-based outputs to make them distinct from cycle-based outputs.  Time and cycle based dumps are useful for different things, and should not be lumped in together.