### PR TITLE
Return metal density cap.

### DIFF
--- a/src/enzo/Grid_GrackleWrapper.C
+++ b/src/enzo/Grid_GrackleWrapper.C
@@ -163,6 +163,17 @@ int grid::GrackleWrapper()
     else if (SNColourNum != -1)
       MetalPointer = BaryonField[SNColourNum];
   } // ENDELSE both metal types
+
+  /*
+    Cap the metal density at 90% of the gas density.
+    This was historically in Enzo, then Grackle and was removed in
+    Grackle PR #121 (https://github.com/grackle-project/grackle/pull/121)
+  */
+  if (MetalPointer != NULL) {
+    for (i = 0; i < size; i++) {
+      MetalPointer[i] = min(MetalPointer[i], 0.9 * BaryonField[DensNum][i]);
+    }
+  }
  
   int temp_thermal = FALSE;
   float *thermal_energy;


### PR DESCRIPTION
This fixes an issue introduced in [Grackle PR #121](https://github.com/grackle-project/grackle/pull/121), where we removed a seemingly arbitrary cap on the metal density. This cap is necessary in Enzo as star formation feedback can produce grid cells where the metal density exceeds the gas density. This may not be either the best fix or the best place to put it, but this PR is as close to restoring prior functionality as is possible without putting it back into Grackle, which we don't want to do. I'm happy for this PR to be a place for a broader conversation.