### PR TITLE
Fix and enhancement for libyt in situ feature

### DIFF
--- a/doc/manual/source/parameters/index.rst
+++ b/doc/manual/source/parameters/index.rst
@@ -3897,6 +3897,17 @@ libyt In Situ Python Analysis
 
     Similar to :ref:`cycle_base_output`.
 
+``dtLibytCall`` (external)
+    Control the time-based libyt calls. The time interval between libyt calls. Zero turns off the time-based outputs. (Default: 0.0)
+
+    Similar to :ref:`time_base_output`.
+
+``TimeLastLibytCall`` (internal)
+    Control the time-based libyt calls.
+    The last time on which a timed libyt call was made.
+
+    Similar to :ref:`time_base_output`.
+
 ``NumberOfLibytCalls`` (internal)
     Internal parameter tracked by Enzo.
 

--- a/doc/manual/source/user_guide/ControllingDataOutput.rst
+++ b/doc/manual/source/user_guide/ControllingDataOutput.rst
@@ -116,6 +116,8 @@ CycleLastDataDump. (So if you change CycleSkipDataDump from 0 to 10
 from a Redshift dump at n=70, you'll get an output every timestep
 for 7 timesteps.)
 
+.. _time_base_output:
+
 Time Based Output
 ~~~~~~~~~~~~~~~~~
 

--- a/doc/manual/source/user_guide/InSituPythonAnalysis.rst
+++ b/doc/manual/source/user_guide/InSituPythonAnalysis.rst
@@ -109,14 +109,19 @@ General
 
 * **How to call libyt in situ analysis routine?**
 
-  Enzo parameter ``CycleSkipLibytCall`` (default is ``1``) and ``CycleLastLibytCall`` (default is ``0``) govern when to call in situ analysis routine.
+  Enzo parameter ``CycleSkipLibytCall`` (default is ``1``)/``CycleLastLibytCall`` (default is ``0``) for cycle-based libyt call
+  and ``dtLibytCall`` (default is ``0.0``) for time-based libyt call govern when to call in situ analysis routine.
   We can change the interval of calling libyt routine or completely close it (set to ``0``) by setting them in Enzo parameter file:
 
   ::
 
       CycleSkipLibytCall = 2  // call libyt routine every 2 cycles
 
-  The logic is similar to how cycle-based output parameters work. (See :ref:`cycle_base_output`)
+  ::
+
+      dtLibytCall = 0.1       // call libyt routine every 0.1 time unit
+
+  The logic is similar to how cycle-based and time-based output data dump parameters work. (See :ref:`cycle_base_output` and :ref:`time_base_output`.)
 
 * **How to call Python functions during simulation runtime? And what should I be aware of?**
 

--- a/doc/manual/source/user_guide/InSituPythonAnalysis.rst
+++ b/doc/manual/source/user_guide/InSituPythonAnalysis.rst
@@ -21,7 +21,7 @@ We can compile ``libyt`` using different options based on our used cases, so tha
 A brief description of each mode (option) is shown here. The options are for compiling ``libyt`` only. The serial and parallel modes are mutually exclusive, as are the normal, interactive, and Jupyter kernal modes.
 Please follow the instructions in ``libyt`` `how to install <https://libyt.readthedocs.io/en/latest/how-to-install/how-to-install.html#how-to-install>`__:
 
-* `libyt`_ (>=0.3.0, <1.0): a C shared library for in situ analysis.
+* `libyt`_ (>=0.4.0, <1.0): a C shared library for in situ analysis.
 
   * **Serial Mode** (``-DSERIAL_MODE=ON``): Compile ``libyt`` using GCC compiler.
 

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -228,7 +228,7 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
     yt_get_ParticlesPtr(&particle_list);
 
     // TODO: make sure enzo's particle is always DarkMatter
-    particle_list[0].par_type = "DarkMatter";
+    particle_list[0].par_type = "io";
 
     // We have the attributes: 3 positions, 3 velocities, "mass", ID and Type
     // and extras.
@@ -257,8 +257,33 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
                                "typeia_fraction"
 #endif
                               };
+	const char *attr_unit[] = {"code_length",
+		                       "code_length",
+							   "code_length",
+                               "code_velocity",
+                               "code_velocity",
+                               "code_velocity",
+							   "code_mass",
+							   "",
+							   "",
+#ifdef WINDS
+							   "code_time",
+							   "code_time",
+							   "",
+							   "",
+							   "",
+							   "",
+							   "",
+#else
+							   "code_time",
+							   "code_time",
+							   "",
+							   ""
+#endif
+							  };
     for (int v = 0; v < particle_list[0].num_attr; v++) {
         particle_list[0].attr_list[v].attr_name = attr_name[v];
+		particle_list[0].attr_list[v].attr_unit = attr_unit[v];
         particle_list[0].attr_list[v].attr_dtype = (v < 3) ? EYT_PFLOAT : EYT_BFLOAT;
     }
     // Now go back and reset it for index and type

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -228,7 +228,7 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
     yt_get_ParticlesPtr(&particle_list);
 
     // TODO: make sure enzo's particle is always DarkMatter
-    particle_list[0].par_type = "io";
+    particle_list[0].par_type = "DarkMatter";
 
     // We have the attributes: 3 positions, 3 velocities, "mass", ID and Type
     // and extras.

--- a/src/enzo/CheckForLibytCall.C
+++ b/src/enzo/CheckForLibytCall.C
@@ -29,7 +29,7 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
                     int level, int from_topgrid);
 
 int CheckForLibytCall(LevelHierarchyEntry *LevelArray[], TopGridData &MetaData) {
-     /* Check for libyt call: cycle-based. */
+  /* Check for libyt call: cycle-based. */
   if (MetaData.CycleNumber >= CycleLastLibytCall + CycleSkipLibytCall   &&
       CycleSkipLibytCall > 0) {
 
@@ -38,7 +38,19 @@ int CheckForLibytCall(LevelHierarchyEntry *LevelArray[], TopGridData &MetaData) 
     // Call libyt in situ routine
     CallInSitulibyt(LevelArray, &MetaData, 0, 1);
   }
-    return SUCCESS;
+
+  /* Check for libyt call: time-based. */
+  if (MetaData.Time >= TimeLastLibytCall + dtLibytCall &&
+      dtLibytCall > 0.0) {
+
+    TimeLastLibytCall += dtLibytCall;
+    std::cout << "(CheckForLibytCall) TimeLastLibytCall -- after: " << TimeLastLibytCall << std::endl;
+
+    // Call libyt in situ routine
+    CallInSitulibyt(LevelArray, &MetaData, 0, 1);
+  }
+
+  return SUCCESS;
 }
 
 #endif // #ifdef USE_LIBYT

--- a/src/enzo/EvolveHierarchy.C
+++ b/src/enzo/EvolveHierarchy.C
@@ -420,6 +420,12 @@ int EvolveHierarchy(HierarchyEntry &TopGrid, TopGridData &MetaData,
         dt = min(1.0001*(MetaData.TimeLastDataDump + MetaData.dtDataDump -
               MetaData.Time), dt);
       }
+      if (dtLibytCall > 0.0) {
+        while (TimeLastLibytCall + dtLibytCall < MetaData.Time) {
+          TimeLastLibytCall += dtLibytCall;
+        }
+        dt = min(1.0001*(TimeLastLibytCall + dtLibytCall - MetaData.Time), dt);
+      }
 
       /* Set the time step.  If it will cause Time += dt > StopTime, then
          set dt = StopTime - Time */

--- a/src/enzo/EvolveHierarchy.C
+++ b/src/enzo/EvolveHierarchy.C
@@ -262,6 +262,12 @@ int EvolveHierarchy(HierarchyEntry &TopGrid, TopGridData &MetaData,
 		 Restart);
 
   PrintMemoryUsage("Output");
+
+#ifdef USE_LIBYT
+    LCAPERF_START("CallInSitulibyt");
+    CheckForLibytCall(LevelArray, MetaData);
+    LCAPERF_STOP("CallInSitulibyt");
+#endif
  
   /* Compute the acceleration field so ComputeTimeStep can find dtAccel.
      (Actually, this is a huge pain-in-the-ass, so only do it if the

--- a/src/enzo/EvolveHierarchy.C
+++ b/src/enzo/EvolveHierarchy.C
@@ -420,12 +420,14 @@ int EvolveHierarchy(HierarchyEntry &TopGrid, TopGridData &MetaData,
         dt = min(1.0001*(MetaData.TimeLastDataDump + MetaData.dtDataDump -
               MetaData.Time), dt);
       }
+#ifdef USE_LIBYT
       if (dtLibytCall > 0.0) {
         while (TimeLastLibytCall + dtLibytCall < MetaData.Time) {
           TimeLastLibytCall += dtLibytCall;
         }
         dt = min(1.0001*(TimeLastLibytCall + dtLibytCall - MetaData.Time), dt);
       }
+#endif
 
       /* Set the time step.  If it will cause Time += dt > StopTime, then
          set dt = StopTime - Time */

--- a/src/enzo/Grid_ConvertToLibyt.C
+++ b/src/enzo/Grid_ConvertToLibyt.C
@@ -52,12 +52,12 @@ void grid::ConvertToLibyt(int LocalGridID, int GlobalGridID, int ParentID, int l
      * In here, we'll happily do whatever we're told.
      *
      * */
-    float grid_unit_length[MAX_DIMENSION] = {1.0, 1.0, 1.0};
+    float cell_width[MAX_DIMENSION] = {1.0, 1.0, 1.0};
     for (int i = 0; i < MAX_DIMENSION; i++) {
         GridInfo.grid_dimensions[i] = (this->GridEndIndex[i]) - (this->GridStartIndex[i]) + 1; // this is active dimension
         GridInfo.left_edge[i] = this->GridLeftEdge[i];
         GridInfo.right_edge[i] = this->GridRightEdge[i];
-        grid_unit_length[i] = (GridInfo.right_edge[i] - GridInfo.left_edge[i]) / GridInfo.grid_dimensions[i];
+        cell_width[i] = (GridInfo.right_edge[i] - GridInfo.left_edge[i]) / GridInfo.grid_dimensions[i];
     }
     GridInfo.id = GlobalGridID;
     GridInfo.parent_id = ParentID;
@@ -126,7 +126,7 @@ void grid::ConvertToLibyt(int LocalGridID, int GlobalGridID, int ParentID, int l
         // Get real particle mass
         float *particle_mass = new float [this->ReturnNumberOfParticles()];
         for (int i = 0; i < this->ReturnNumberOfParticles(); i++) {
-            particle_mass[i] = this->ParticleMass[i] * grid_unit_length[0] * grid_unit_length[1] * grid_unit_length[2];
+            particle_mass[i] = this->ParticleMass[i] * cell_width[0] * cell_width[1] * cell_width[2];
         }
         libyt_generated_data.push_back(particle_mass);
 

--- a/src/enzo/InitializeLibytInterface.C
+++ b/src/enzo/InitializeLibytInterface.C
@@ -26,6 +26,12 @@
 #define YT_SET_USERPARAM_NONINTEGER(X, Y, Z) yt_set_UserParameterDouble(X, Y, Z)
 #endif
 
+#ifdef CONFIG_PFLOAT_4
+#define YT_SET_USERPARAM_PNONINTEGER(X, Y, Z) yt_set_UserParameterFloat(X, Y, Z)
+#else
+#define YT_SET_USERPARAM_PNONINTEGER(X, Y, Z) yt_set_UserParameterDouble(X, Y, Z)
+#endif
+
 #ifdef SMALL_INTS
 #define YT_SET_USERPARAM_INTEGER(X, Y, Z) yt_set_UserParameterInt(X, Y, Z)
 #else
@@ -112,12 +118,12 @@ void ExportParameterFileToLibyt(TopGridData *MetaData, FLOAT CurrentTime, FLOAT 
     CosmologyComputeExpansionFactor(CurrentTime, &a, &dadt);
     CurrentRedshift = (1 + InitialRedshift)/a - 1;
 
-    YT_SET_USERPARAM_NONINTEGER("CosmologyCurrentRedshift", 1, &CurrentRedshift);
+    YT_SET_USERPARAM_PNONINTEGER("CosmologyCurrentRedshift", 1, &CurrentRedshift);
     YT_SET_USERPARAM_NONINTEGER("CosmologyComovingBoxSize", 1, &ComovingBoxSize);
     YT_SET_USERPARAM_NONINTEGER("CosmologyOmegaMatterNow", 1, &OmegaMatterNow);
     YT_SET_USERPARAM_NONINTEGER("CosmologyOmegaLambdaNow", 1, &OmegaLambdaNow);
     YT_SET_USERPARAM_NONINTEGER("CosmologyHubbleConstantNow", 1, &HubbleConstantNow);
-    YT_SET_USERPARAM_NONINTEGER("CosmologyInitialRedshift", 1, &InitialRedshift);
+    YT_SET_USERPARAM_PNONINTEGER("CosmologyInitialRedshift", 1, &InitialRedshift);
   }
 
   YT_SET_USERPARAM_NONINTEGER("DensityUnits", 1, &DensityUnits);
@@ -126,9 +132,9 @@ void ExportParameterFileToLibyt(TopGridData *MetaData, FLOAT CurrentTime, FLOAT 
   YT_SET_USERPARAM_NONINTEGER("TimeUnits", 1, &TimeUnits);
   YT_SET_USERPARAM_INTEGER("HydroMethod", 1, &HydroMethod);
   YT_SET_USERPARAM_INTEGER("DualEnergyFormalism", 1, &DualEnergyFormalism);
-  YT_SET_USERPARAM_NONINTEGER("InitialTime", 1, &CurrentTime);
-  YT_SET_USERPARAM_NONINTEGER("StopTime", 1, &MetaData->StopTime);
-  YT_SET_USERPARAM_NONINTEGER("OldTime", 1, &OldTime);
+  YT_SET_USERPARAM_PNONINTEGER("InitialTime", 1, &CurrentTime);
+  YT_SET_USERPARAM_PNONINTEGER("StopTime", 1, &MetaData->StopTime);
+  YT_SET_USERPARAM_PNONINTEGER("OldTime", 1, &OldTime);
   YT_SET_USERPARAM_NONINTEGER("dtFixed", 1, &dtFixed);
   YT_SET_USERPARAM_INTEGER("ComovingCoordinates", 1, &ComovingCoordinates);
 
@@ -151,8 +157,8 @@ void ExportParameterFileToLibyt(TopGridData *MetaData, FLOAT CurrentTime, FLOAT 
   YT_SET_USERPARAM_NONINTEGER("CurrentMaximumDensity", 1, &CurrentMaximumDensity);
   YT_SET_USERPARAM_NONINTEGER("AngularVelocity", 1, &AngularVelocity);
   YT_SET_USERPARAM_NONINTEGER("VelocityGradient", 1, &VelocityGradient);
-  YT_SET_USERPARAM_NONINTEGER("dtDataDump", 1, &MetaData->dtDataDump);
-  YT_SET_USERPARAM_NONINTEGER("TimeLastDataDump", 1, &MetaData->TimeLastDataDump);
+  YT_SET_USERPARAM_PNONINTEGER("dtDataDump", 1, &MetaData->dtDataDump);
+  YT_SET_USERPARAM_PNONINTEGER("TimeLastDataDump", 1, &MetaData->TimeLastDataDump);
   YT_SET_USERPARAM_INTEGER("WroteData", 1, &MetaData->WroteData);
 
   YT_SET_USERPARAM_INTEGER("TopGridDimensions", MAX_DIMENSION, MetaData->TopGridDims);

--- a/src/enzo/InitializeLibytInterface_finderfunctions.inc
+++ b/src/enzo/InitializeLibytInterface_finderfunctions.inc
@@ -4,6 +4,12 @@
 #define YT_SET_USERPARAM_NONINTEGER(X, Y, Z) yt_set_UserParameterDouble(X, Y, Z)
 #endif
 
+#ifdef CONFIG_PFLOAT_4
+#define YT_SET_USERPARAM_PNONINTEGER(X, Y, Z) yt_set_UserParameterFloat(X, Y, Z)
+#else
+#define YT_SET_USERPARAM_PNONINTEGER(X, Y, Z) yt_set_UserParameterDouble(X, Y, Z)
+#endif
+
 #ifdef SMALL_INTS
 #define YT_SET_USERPARAM_INTEGER(X, Y, Z) yt_set_UserParameterInt(X, Y, Z)
 #else
@@ -44,8 +50,8 @@ YT_SET_USERPARAM_INTEGER("MaximumGravityRefinementLevel", 1, &MaximumGravityRefi
 YT_SET_USERPARAM_INTEGER("MaximumParticleRefinementLevel", 1, &MaximumParticleRefinementLevel);
 YT_SET_USERPARAM_INTEGER("FastSiblingLocatorEntireDomain", 1, &FastSiblingLocatorEntireDomain);
 YT_SET_USERPARAM_INTEGER("CellFlaggingMethod", MAX_FLAGGING_METHODS, CellFlaggingMethod);
-yt_set_UserParameterDouble("MustRefineRegionLeftEdge", MAX_DIMENSION, MustRefineRegionLeftEdge);
-yt_set_UserParameterDouble("MustRefineRegionRightEdge", MAX_DIMENSION, MustRefineRegionRightEdge);
+YT_SET_USERPARAM_PNONINTEGER("MustRefineRegionLeftEdge", MAX_DIMENSION, MustRefineRegionLeftEdge);
+YT_SET_USERPARAM_PNONINTEGER("MustRefineRegionRightEdge", MAX_DIMENSION, MustRefineRegionRightEdge);
 YT_SET_USERPARAM_INTEGER("AvoidRefineRegionLevel", MAX_STATIC_REGIONS, AvoidRefineRegionLevel);
 YT_SET_USERPARAM_INTEGER("MustRefineRegionMinRefinementLevel", 1, &MustRefineRegionMinRefinementLevel);
 YT_SET_USERPARAM_INTEGER("MetallicityRefinementMinLevel", 1, &MetallicityRefinementMinLevel);
@@ -63,8 +69,8 @@ YT_SET_USERPARAM_INTEGER("MinimumSubgridEdge", 1, &MinimumSubgridEdge);
 YT_SET_USERPARAM_INTEGER("MaximumSubgridSize", 1, &MaximumSubgridSize);
 YT_SET_USERPARAM_NONINTEGER("CriticalGridRatio", 1, &CriticalGridRatio);
 YT_SET_USERPARAM_INTEGER("NumberOfBufferZones", 1, &NumberOfBufferZones);
-yt_set_UserParameterDouble("DomainLeftEdge", MAX_DIMENSION, DomainLeftEdge);
-yt_set_UserParameterDouble("DomainRightEdge", MAX_DIMENSION, DomainRightEdge);
+YT_SET_USERPARAM_PNONINTEGER("DomainLeftEdge", MAX_DIMENSION, DomainLeftEdge);
+YT_SET_USERPARAM_PNONINTEGER("DomainRightEdge", MAX_DIMENSION, DomainRightEdge);
 YT_SET_USERPARAM_NONINTEGER("GridVelocity", MAX_DIMENSION, GridVelocity);
 for (i = 0; i < MAX_DIMENSION; i++){
     snprintf(tempname, 255, "DimUnits_%d", i);
@@ -86,28 +92,28 @@ for (i = 0; i < MAX_NUMBER_OF_BARYON_FIELDS; i++){
     if (!DataUnits[i]) continue;
     yt_set_UserParameterString(tempname, DataUnits[i]);
 }
-yt_set_UserParameterDouble("RefineRegionLeftEdge", MAX_DIMENSION, RefineRegionLeftEdge);
-yt_set_UserParameterDouble("RefineRegionRightEdge", MAX_DIMENSION, RefineRegionRightEdge);
+YT_SET_USERPARAM_PNONINTEGER("RefineRegionLeftEdge", MAX_DIMENSION, RefineRegionLeftEdge);
+YT_SET_USERPARAM_PNONINTEGER("RefineRegionRightEdge", MAX_DIMENSION, RefineRegionRightEdge);
 YT_SET_USERPARAM_INTEGER("RefineRegionAutoAdjust", 1, &RefineRegionAutoAdjust);
 YT_SET_USERPARAM_INTEGER("MultiRefineRegion", 1, &MultiRefineRegion);
 YT_SET_USERPARAM_INTEGER("MultiRefineRegionGeometry", MAX_STATIC_REGIONS, MultiRefineRegionGeometry);
-yt_set_UserParameterDouble("MultiRefineRegionRadius", MAX_STATIC_REGIONS, MultiRefineRegionRadius);
-yt_set_UserParameterDouble("MultiRefineRegionWidth", MAX_STATIC_REGIONS, MultiRefineRegionWidth);
+YT_SET_USERPARAM_PNONINTEGER("MultiRefineRegionRadius", MAX_STATIC_REGIONS, MultiRefineRegionRadius);
+YT_SET_USERPARAM_PNONINTEGER("MultiRefineRegionWidth", MAX_STATIC_REGIONS, MultiRefineRegionWidth);
 YT_SET_USERPARAM_INTEGER("MultiRefineRegionMaximumLevel", MAX_STATIC_REGIONS, MultiRefineRegionMaximumLevel);
 YT_SET_USERPARAM_INTEGER("MultiRefineRegionMinimumLevel", MAX_STATIC_REGIONS, MultiRefineRegionMinimumLevel);
 YT_SET_USERPARAM_INTEGER("MultiRefineRegionMaximumOuterLevel", 1, &MultiRefineRegionMaximumOuterLevel);
 YT_SET_USERPARAM_INTEGER("MultiRefineRegionMinimumOuterLevel", 1, &MultiRefineRegionMinimumOuterLevel);
-yt_set_UserParameterDouble("MultiRefineRegionStaggeredRefinement", MAX_STATIC_REGIONS, MultiRefineRegionStaggeredRefinement);
+YT_SET_USERPARAM_PNONINTEGER("MultiRefineRegionStaggeredRefinement", MAX_STATIC_REGIONS, MultiRefineRegionStaggeredRefinement);
 YT_SET_USERPARAM_INTEGER("UniformGravity", 1, &UniformGravity);
 YT_SET_USERPARAM_INTEGER("UniformGravityDirection", 1, &UniformGravityDirection);
 YT_SET_USERPARAM_NONINTEGER("UniformGravityConstant", 1, &UniformGravityConstant);
 YT_SET_USERPARAM_INTEGER("PointSourceGravity", 1, &PointSourceGravity);
-yt_set_UserParameterDouble("PointSourceGravityPosition", MAX_DIMENSION, PointSourceGravityPosition);
+YT_SET_USERPARAM_PNONINTEGER("PointSourceGravityPosition", MAX_DIMENSION, PointSourceGravityPosition);
 YT_SET_USERPARAM_NONINTEGER("PointSourceGravityConstant", 1, &PointSourceGravityConstant);
 YT_SET_USERPARAM_NONINTEGER("PointSourceGravityCoreRadius", 1, &PointSourceGravityCoreRadius);
 YT_SET_USERPARAM_INTEGER("DiskGravity", 1, &DiskGravity);
-yt_set_UserParameterDouble("DiskGravityPosition", MAX_DIMENSION, DiskGravityPosition);
-yt_set_UserParameterDouble("DiskGravityAngularMomentum", MAX_DIMENSION, DiskGravityAngularMomentum);
+YT_SET_USERPARAM_PNONINTEGER("DiskGravityPosition", MAX_DIMENSION, DiskGravityPosition);
+YT_SET_USERPARAM_PNONINTEGER("DiskGravityAngularMomentum", MAX_DIMENSION, DiskGravityAngularMomentum);
 yt_set_UserParameterDouble("DiskGravityStellarDiskMass", 1, &DiskGravityStellarDiskMass);
 yt_set_UserParameterDouble("DiskGravityStellarDiskScaleHeightR", 1, &DiskGravityStellarDiskScaleHeightR);
 yt_set_UserParameterDouble("DiskGravityStellarDiskScaleHeightz", 1, &DiskGravityStellarDiskScaleHeightz);
@@ -135,8 +141,8 @@ YT_SET_USERPARAM_INTEGER("RadiativeCoolingModel", 1, &RadiativeCoolingModel);
 YT_SET_USERPARAM_INTEGER("use_grackle", 1, &use_grackle);
 YT_SET_USERPARAM_INTEGER("GadgetEquilibriumCooling", 1, &GadgetEquilibriumCooling);
 YT_SET_USERPARAM_INTEGER("RandomForcing", 1, &RandomForcing);
-yt_set_UserParameterDouble("RandomForcingEdot", 1, &RandomForcingEdot);
-yt_set_UserParameterDouble("RandomForcingMachNumber", 1, &RandomForcingMachNumber);
+YT_SET_USERPARAM_PNONINTEGER("RandomForcingEdot", 1, &RandomForcingEdot);
+YT_SET_USERPARAM_PNONINTEGER("RandomForcingMachNumber", 1, &RandomForcingMachNumber);
 YT_SET_USERPARAM_INTEGER("DrivenFlowAlpha", MAX_DIMENSION, DrivenFlowAlpha);
 YT_SET_USERPARAM_INTEGER("DrivenFlowSeed", 1, &DrivenFlowSeed);
 YT_SET_USERPARAM_NONINTEGER("DrivenFlowWeight", 1, &DrivenFlowWeight);
@@ -211,22 +217,22 @@ if (RefineRegionFile)
     yt_set_UserParameterString("RefineRegionFile", RefineRegionFile);
 YT_SET_USERPARAM_INTEGER("RefineRegionTimeType", 1, &RefineRegionTimeType);
 YT_SET_USERPARAM_INTEGER("EvolveRefineRegionNtimes", 1, &EvolveRefineRegionNtimes);
-yt_set_UserParameterDouble("EvolveRefineRegionTime", MAX_REFINE_REGIONS, EvolveRefineRegionTime);
+YT_SET_USERPARAM_PNONINTEGER("EvolveRefineRegionTime", MAX_REFINE_REGIONS, EvolveRefineRegionTime);
 if (MustRefineRegionFile)
     yt_set_UserParameterString("MustRefineRegionFile", MustRefineRegionFile);
 YT_SET_USERPARAM_INTEGER("MustRefineRegionTimeType", 1, &MustRefineRegionTimeType);
 YT_SET_USERPARAM_INTEGER("EvolveMustRefineRegionNtimes", 1, &EvolveMustRefineRegionNtimes);
-yt_set_UserParameterDouble("EvolveMustRefineRegionTime", MAX_REFINE_REGIONS, EvolveMustRefineRegionTime);
+YT_SET_USERPARAM_PNONINTEGER("EvolveMustRefineRegionTime", MAX_REFINE_REGIONS, EvolveMustRefineRegionTime);
 YT_SET_USERPARAM_INTEGER("EvolveMustRefineRegionMinLevel", MAX_REFINE_REGIONS, EvolveMustRefineRegionMinLevel);
 YT_SET_USERPARAM_INTEGER("UseCoolingRefineRegion", 1, &UseCoolingRefineRegion);
 YT_SET_USERPARAM_INTEGER("EvolveCoolingRefineRegion", 1, &EvolveCoolingRefineRegion);
-yt_set_UserParameterDouble("CoolingRefineRegionLeftEdge", MAX_DIMENSION, CoolingRefineRegionLeftEdge);
-yt_set_UserParameterDouble("CoolingRefineRegionRightEdge", MAX_DIMENSION, CoolingRefineRegionRightEdge);
+YT_SET_USERPARAM_PNONINTEGER("CoolingRefineRegionLeftEdge", MAX_DIMENSION, CoolingRefineRegionLeftEdge);
+YT_SET_USERPARAM_PNONINTEGER("CoolingRefineRegionRightEdge", MAX_DIMENSION, CoolingRefineRegionRightEdge);
 if (CoolingRefineRegionFile)
     yt_set_UserParameterString("CoolingRefineRegionFile", CoolingRefineRegionFile);
 YT_SET_USERPARAM_INTEGER("CoolingRefineRegionTimeType", 1, &CoolingRefineRegionTimeType);
 YT_SET_USERPARAM_INTEGER("EvolveCoolingRefineRegionNtimes", 1, &EvolveCoolingRefineRegionNtimes);
-yt_set_UserParameterDouble("EvolveCoolingRefineRegionTime", MAX_REFINE_REGIONS, EvolveCoolingRefineRegionTime);
+YT_SET_USERPARAM_PNONINTEGER("EvolveCoolingRefineRegionTime", MAX_REFINE_REGIONS, EvolveCoolingRefineRegionTime);
 YT_SET_USERPARAM_INTEGER("MyProcessorNumber", 1, &MyProcessorNumber);
 YT_SET_USERPARAM_INTEGER("NumberOfProcessors", 1, &NumberOfProcessors);
 YT_SET_USERPARAM_NONINTEGER("CommunicationTime", 1, &CommunicationTime);
@@ -262,7 +268,7 @@ YT_SET_USERPARAM_INTEGER("HaloFinderCycleSkip", 1, &HaloFinderCycleSkip);
 YT_SET_USERPARAM_INTEGER("HaloFinderRunAfterOutput", 1, &HaloFinderRunAfterOutput);
 YT_SET_USERPARAM_NONINTEGER("HaloFinderLinkingLength", 1, &HaloFinderLinkingLength);
 YT_SET_USERPARAM_NONINTEGER("HaloFinderTimestep", 1, &HaloFinderTimestep);
-yt_set_UserParameterDouble("HaloFinderLastTime", 1, &HaloFinderLastTime);
+YT_SET_USERPARAM_PNONINTEGER("HaloFinderLastTime", 1, &HaloFinderLastTime);
 YT_SET_USERPARAM_NONINTEGER("MinimumSlopeForRefinement", MAX_FLAGGING_METHODS, MinimumSlopeForRefinement);
 YT_SET_USERPARAM_INTEGER("SlopeFlaggingFields", MAX_FLAGGING_METHODS, SlopeFlaggingFields);
 YT_SET_USERPARAM_NONINTEGER("MinimumOverDensityForRefinement", MAX_FLAGGING_METHODS, MinimumOverDensityForRefinement);
@@ -276,8 +282,8 @@ YT_SET_USERPARAM_NONINTEGER("JeansRefinementColdTemperature", 1, &JeansRefinemen
 YT_SET_USERPARAM_INTEGER("MustRefineParticlesRefineToLevel", 1, &MustRefineParticlesRefineToLevel);
 YT_SET_USERPARAM_INTEGER("MustRefineParticlesRefineToLevelAutoAdjust", 1, &MustRefineParticlesRefineToLevelAutoAdjust);
 YT_SET_USERPARAM_NONINTEGER("MustRefineParticlesMinimumMass", 1, &MustRefineParticlesMinimumMass);
-yt_set_UserParameterDouble("MustRefineParticlesLeftEdge", MAX_DIMENSION, MustRefineParticlesLeftEdge);
-yt_set_UserParameterDouble("MustRefineParticlesRightEdge", MAX_DIMENSION, MustRefineParticlesRightEdge);
+YT_SET_USERPARAM_PNONINTEGER("MustRefineParticlesLeftEdge", MAX_DIMENSION, MustRefineParticlesLeftEdge);
+YT_SET_USERPARAM_PNONINTEGER("MustRefineParticlesRightEdge", MAX_DIMENSION, MustRefineParticlesRightEdge);
 YT_SET_USERPARAM_INTEGER("MustRefineParticlesCreateParticles", 1, &MustRefineParticlesCreateParticles);
 YT_SET_USERPARAM_NONINTEGER("MinimumShearForRefinement", 1, &MinimumShearForRefinement);
 YT_SET_USERPARAM_INTEGER("OldShearMethod", 1, &OldShearMethod);
@@ -302,8 +308,8 @@ yt_set_UserParameterDouble("SimpleQ", 1, &SimpleQ);
 YT_SET_USERPARAM_NONINTEGER("SimpleRampTime", 1, &SimpleRampTime);
 YT_SET_USERPARAM_INTEGER("StarFormationOncePerRootGridTimeStep", 1, &StarFormationOncePerRootGridTimeStep);
 YT_SET_USERPARAM_INTEGER("TimeActionType", MAX_TIME_ACTIONS, TimeActionType);
-yt_set_UserParameterDouble("TimeActionTime", MAX_TIME_ACTIONS, TimeActionTime);
-yt_set_UserParameterDouble("TimeActionRedshift", MAX_TIME_ACTIONS, TimeActionRedshift);
+YT_SET_USERPARAM_PNONINTEGER("TimeActionTime", MAX_TIME_ACTIONS, TimeActionTime);
+YT_SET_USERPARAM_PNONINTEGER("TimeActionRedshift", MAX_TIME_ACTIONS, TimeActionRedshift);
 YT_SET_USERPARAM_NONINTEGER("TimeActionParameter", MAX_TIME_ACTIONS, TimeActionParameter);
 for (i = 0; i < MAX_CUBE_DUMPS; i++){
     snprintf(tempname, 255, "CubeDumps_%d", i);
@@ -312,9 +318,9 @@ for (i = 0; i < MAX_CUBE_DUMPS; i++){
 }
 YT_SET_USERPARAM_INTEGER("TracerParticleOn", 1, &TracerParticleOn);
 YT_SET_USERPARAM_INTEGER("TracerParticleOutputVelocity", 1, &TracerParticleOutputVelocity);
-yt_set_UserParameterDouble("TracerParticleCreationSpacing", 1, &TracerParticleCreationSpacing);
-yt_set_UserParameterDouble("TracerParticleCreationLeftEdge", MAX_DIMENSION, TracerParticleCreationLeftEdge);
-yt_set_UserParameterDouble("TracerParticleCreationRightEdge", MAX_DIMENSION, TracerParticleCreationRightEdge);
+YT_SET_USERPARAM_PNONINTEGER("TracerParticleCreationSpacing", 1, &TracerParticleCreationSpacing);
+YT_SET_USERPARAM_PNONINTEGER("TracerParticleCreationLeftEdge", MAX_DIMENSION, TracerParticleCreationLeftEdge);
+YT_SET_USERPARAM_PNONINTEGER("TracerParticleCreationRightEdge", MAX_DIMENSION, TracerParticleCreationRightEdge);
 YT_SET_USERPARAM_INTEGER("ParticleTypeInFile", 1, &ParticleTypeInFile);
 YT_SET_USERPARAM_INTEGER("OutputParticleTypeGrouping", 1, &OutputParticleTypeGrouping);
 YT_SET_USERPARAM_INTEGER("ExternalBoundaryIO", 1, &ExternalBoundaryIO);
@@ -402,9 +408,9 @@ yt_set_UserParameterDouble("HaloCentralDensity", 1, &HaloCentralDensity);
 yt_set_UserParameterDouble("HaloVirialRadius", 1, &HaloVirialRadius);
 YT_SET_USERPARAM_NONINTEGER("ExternalGravityConstant", 1, &ExternalGravityConstant);
 YT_SET_USERPARAM_NONINTEGER("ExternalGravityDensity", 1, &ExternalGravityDensity);
-yt_set_UserParameterDouble("ExternalGravityPosition", MAX_DIMENSION, ExternalGravityPosition);
+YT_SET_USERPARAM_PNONINTEGER("ExternalGravityPosition", MAX_DIMENSION, ExternalGravityPosition);
 yt_set_UserParameterDouble("ExternalGravityRadius", 1, &ExternalGravityRadius);
-yt_set_UserParameterDouble("ExternalGravityOrientation", MAX_DIMENSION, ExternalGravityOrientation);
+YT_SET_USERPARAM_PNONINTEGER("ExternalGravityOrientation", MAX_DIMENSION, ExternalGravityOrientation);
 YT_SET_USERPARAM_INTEGER("UsePoissonDivergenceCleaning", 1, &UsePoissonDivergenceCleaning);
 YT_SET_USERPARAM_INTEGER("PoissonDivergenceCleaningBoundaryBuffer", 1, &PoissonDivergenceCleaningBoundaryBuffer);
 YT_SET_USERPARAM_NONINTEGER("PoissonDivergenceCleaningThreshold", 1, &PoissonDivergenceCleaningThreshold);
@@ -436,7 +442,7 @@ YT_SET_USERPARAM_INTEGER("CIECooling", 1, &CIECooling);
 YT_SET_USERPARAM_INTEGER("H2OpticalDepthApproximation", 1, &H2OpticalDepthApproximation);
 YT_SET_USERPARAM_INTEGER("RadiativeTransfer", 1, &RadiativeTransfer);
 YT_SET_USERPARAM_INTEGER("RadiativeTransferHydrogenOnly", 1, &RadiativeTransferHydrogenOnly);
-yt_set_UserParameterDouble("PhotonTime", 1, &PhotonTime);
+YT_SET_USERPARAM_PNONINTEGER("PhotonTime", 1, &PhotonTime);
 YT_SET_USERPARAM_NONINTEGER("dtPhoton", 1, &dtPhoton);
 yt_set_UserParameterDouble("EscapedPhotonCount", 4, EscapedPhotonCount);
 yt_set_UserParameterDouble("TotalEscapedPhotonCount", 4, TotalEscapedPhotonCount);
@@ -464,7 +470,7 @@ YT_SET_USERPARAM_INTEGER("ShearingVelocityDirection", 1, &ShearingVelocityDirect
 YT_SET_USERPARAM_INTEGER("ShearingOtherDirection", 1, &ShearingOtherDirection);
 YT_SET_USERPARAM_INTEGER("UseMHD", 1, &UseMHD);
 YT_SET_USERPARAM_INTEGER("MaxVelocityIndex", 1, &MaxVelocityIndex);
-yt_set_UserParameterDouble("TopGridDx", MAX_DIMENSION, TopGridDx);
+YT_SET_USERPARAM_PNONINTEGER("TopGridDx", MAX_DIMENSION, TopGridDx);
 YT_SET_USERPARAM_INTEGER("ShearingBoxProblemType", 1, &ShearingBoxProblemType);
 YT_SET_USERPARAM_NONINTEGER("IsothermalSoundSpeed", 1, &IsothermalSoundSpeed);
 YT_SET_USERPARAM_INTEGER("MoveParticlesBetweenSiblings", 1, &MoveParticlesBetweenSiblings);
@@ -475,7 +481,7 @@ YT_SET_USERPARAM_INTEGER("ParticleSplitterMustRefine", 1, &ParticleSplitterMustR
 if (ParticleSplitterMustRefineIDFile)
     yt_set_UserParameterString("ParticleSplitterMustRefineIDFile", ParticleSplitterMustRefineIDFile);
 YT_SET_USERPARAM_NONINTEGER("ParticleSplitterFraction", MAX_SPLIT_ITERATIONS, ParticleSplitterFraction);
-yt_set_UserParameterDouble("ParticleSplitterCenter", MAX_DIMENSION, ParticleSplitterCenter);
+YT_SET_USERPARAM_PNONINTEGER("ParticleSplitterCenter", MAX_DIMENSION, ParticleSplitterCenter);
 YT_SET_USERPARAM_NONINTEGER("ParticleSplitterCenterRegion", MAX_SPLIT_ITERATIONS, ParticleSplitterCenterRegion);
 YT_SET_USERPARAM_INTEGER("ResetMagneticField", 1, &ResetMagneticField);
 YT_SET_USERPARAM_NONINTEGER("ResetMagneticFieldAmplitude", MAX_DIMENSION, ResetMagneticFieldAmplitude);
@@ -534,7 +540,7 @@ YT_SET_USERPARAM_NONINTEGER("StellarWindRadius", 1, &StellarWindRadius);
 YT_SET_USERPARAM_NONINTEGER("StellarWindDensity", 1, &StellarWindDensity);
 YT_SET_USERPARAM_NONINTEGER("StellarWindSpeed", 1, &StellarWindSpeed);
 YT_SET_USERPARAM_NONINTEGER("StellarWindTemperature", 1, &StellarWindTemperature);
-yt_set_UserParameterDouble("StellarWindCenterPosition", 3, StellarWindCenterPosition);
+YT_SET_USERPARAM_PNONINTEGER("StellarWindCenterPosition", 3, StellarWindCenterPosition);
 YT_SET_USERPARAM_INTEGER("MHDCTSlopeLimiter", 1, &MHDCTSlopeLimiter);
 YT_SET_USERPARAM_INTEGER("MHDCTDualEnergyMethod", 1, &MHDCTDualEnergyMethod);
 YT_SET_USERPARAM_INTEGER("MHDCTPowellSource", 1, &MHDCTPowellSource);

--- a/src/enzo/InitializeNew.C
+++ b/src/enzo/InitializeNew.C
@@ -881,9 +881,11 @@ int InitializeNew(char *filename, HierarchyEntry &TopGrid,
     MetaData.TimeLastDataDump = MetaData.Time - MetaData.dtDataDump*1.00001;
   if (MetaData.TimeLastHistoryDump == FLOAT_UNDEFINED)
     MetaData.TimeLastHistoryDump = MetaData.Time - MetaData.dtHistoryDump;
+#ifdef USE_LIBYT
   if (TimeLastLibytCall == FLOAT_UNDEFINED) {
     TimeLastLibytCall = MetaData.Time - dtLibytCall * 1.00001;
   }
+#endif
   
   if (MetaData.TimeLastTracerParticleDump == FLOAT_UNDEFINED)
     MetaData.TimeLastTracerParticleDump =

--- a/src/enzo/InitializeNew.C
+++ b/src/enzo/InitializeNew.C
@@ -881,6 +881,9 @@ int InitializeNew(char *filename, HierarchyEntry &TopGrid,
     MetaData.TimeLastDataDump = MetaData.Time - MetaData.dtDataDump*1.00001;
   if (MetaData.TimeLastHistoryDump == FLOAT_UNDEFINED)
     MetaData.TimeLastHistoryDump = MetaData.Time - MetaData.dtHistoryDump;
+  if (TimeLastLibytCall == FLOAT_UNDEFINED) {
+    TimeLastLibytCall = MetaData.Time - dtLibytCall * 1.00001;
+  }
   
   if (MetaData.TimeLastTracerParticleDump == FLOAT_UNDEFINED)
     MetaData.TimeLastTracerParticleDump =

--- a/src/enzo/ReadParameterFile.C
+++ b/src/enzo/ReadParameterFile.C
@@ -1195,6 +1195,8 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "libyt_fig_basename = %s", libyt_fig_basename);
     ret += sscanf(line, "CycleSkipLibytCall = %"ISYM, &CycleSkipLibytCall);
     ret += sscanf(line, "CycleLastLibytCall = %"ISYM, &CycleLastLibytCall);
+    ret += sscanf(line, "dtLibytCall = %"FSYM, &dtLibytCall);
+    ret += sscanf(line, "TimeLastLibytCall = %"FSYM, &TimeLastLibytCall);
 #endif
 
     /* EnzoTiming Parameters */

--- a/src/enzo/SetDefaultGlobalValues.C
+++ b/src/enzo/SetDefaultGlobalValues.C
@@ -974,6 +974,9 @@ int SetDefaultGlobalValues(TopGridData &MetaData)
   // cycle-based libyt call
   CycleSkipLibytCall = 1;
   CycleLastLibytCall = 0;
+  // time-based libyt call
+  TimeLastLibytCall = FLOAT_UNDEFINED;
+  dtLibytCall = 0.0;
 #endif
 
   /* Some stateful variables for EvolveLevel */

--- a/src/enzo/WriteParameterFile.C
+++ b/src/enzo/WriteParameterFile.C
@@ -185,6 +185,8 @@ int WriteParameterFile(FILE *fptr, TopGridData &MetaData, char *name = NULL)
   fprintf(fptr, "libyt_fig_basename = %s\n", libyt_fig_basename);
   fprintf(fptr, "CycleSkipLibytCall  = %"ISYM"\n", CycleSkipLibytCall);
   fprintf(fptr, "CycleLastLibytCall  = %"ISYM"\n", CycleLastLibytCall);
+  fprintf(fptr, "TimeLastLibytCall    = %"GSYM"\n", TimeLastLibytCall);
+  fprintf(fptr, "dtLibytCall          = %"GSYM"\n", dtLibytCall);
 #endif
 
   fprintf(fptr, "TimingCycleSkip             = %"ISYM"\n", TimingCycleSkip);

--- a/src/enzo/global_data.h
+++ b/src/enzo/global_data.h
@@ -985,6 +985,8 @@ EXTERN char libyt_script_name[512];
 EXTERN char libyt_fig_basename[512];
 EXTERN int CycleSkipLibytCall;
 EXTERN int CycleLastLibytCall;
+EXTERN float dtLibytCall;
+EXTERN float TimeLastLibytCall;
 EXTERN void *param_libyt;
 EXTERN void *param_yt;
 EXTERN std::vector<void*> libyt_generated_data;


### PR DESCRIPTION
## Fix 

- Set unit for `DarkMatter` particle type
- Enzo `particle_mass` is in fact _mass density_, so we need to convert to real mass before setting the pointer.
- `precision-32/64` and `particles-32/64` can compile

## Enhancement

- Add `dtLibytCall` and `TimeLastLibytCall` to govern the time-based libyt call routine in Enzo.
- Check if we need to call libyt routine at initialization steps.
